### PR TITLE
Add twitter, website and biography attributes to user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,4 +12,5 @@ class User < ActiveRecord::Base
   validates :username, format: { with: /\A[a-zA-Z0-9_]+\Z/, message: "is invalid. Alphanumerics only." }, allow_blank: true
   validates :username, length: { maximum: 39 } # This is GitHub's maximum username limit
 
+  validates :website, format: { with: /\A((http|https):\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,}(([0-9]{1,5})?\/.*)?#=\z/ix }, allow_blank: true
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,3 +1,3 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :email, :username
+  attributes :id, :email, :username, :twitter, :biography, :website
 end

--- a/db/migrate/20151124121656_add_twitter_website_biography_to_user.rb
+++ b/db/migrate/20151124121656_add_twitter_website_biography_to_user.rb
@@ -1,7 +1,7 @@
 class AddTwitterWebsiteBiographyToUser < ActiveRecord::Migration
   def change
-    add_column(:users, :website, :string)
-    add_column(:users, :twitter, :string)
-    add_column(:users, :biography, :string)
+    add_column(:users, :website, :text)
+    add_column(:users, :twitter, :text)
+    add_column(:users, :biography, :text)
   end
 end

--- a/db/migrate/20151124121656_add_twitter_website_biography_to_user.rb
+++ b/db/migrate/20151124121656_add_twitter_website_biography_to_user.rb
@@ -1,0 +1,7 @@
+class AddTwitterWebsiteBiographyToUser < ActiveRecord::Migration
+  def change
+    add_column(:users, :website, :string)
+    add_column(:users, :twitter, :string)
+    add_column(:users, :biography, :string)
+  end
+end

--- a/db/migrate/20151124121656_add_twitter_website_biography_to_user.rb
+++ b/db/migrate/20151124121656_add_twitter_website_biography_to_user.rb
@@ -1,7 +1,7 @@
 class AddTwitterWebsiteBiographyToUser < ActiveRecord::Migration
   def change
     add_column(:users, :website, :text)
-    add_column(:users, :twitter, :text)
+    add_column(:users, :twitter, :string)
     add_column(:users, :biography, :text)
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -128,7 +128,7 @@ ActiveRecord::Schema.define(version: 20151124130007) do
     t.string   "username"
     t.boolean  "admin",                          default: false, null: false
     t.text     "website"
-    t.text     "twitter"
+    t.string   "twitter"
     t.text     "biography"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151119113429) do
+ActiveRecord::Schema.define(version: 20151124121656) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -108,6 +108,9 @@ ActiveRecord::Schema.define(version: 20151119113429) do
     t.string   "remember_token",     limit: 128,                 null: false
     t.string   "username"
     t.boolean  "admin",                          default: false, null: false
+    t.string   "website"
+    t.string   "twitter"
+    t.string   "biography"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151124121656) do
+ActiveRecord::Schema.define(version: 20151124130007) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -127,9 +127,9 @@ ActiveRecord::Schema.define(version: 20151124121656) do
     t.string   "remember_token",     limit: 128,                 null: false
     t.string   "username"
     t.boolean  "admin",                          default: false, null: false
-    t.string   "website"
-    t.string   "twitter"
-    t.string   "biography"
+    t.text     "website"
+    t.text     "twitter"
+    t.text     "biography"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", using: :btree

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,6 +9,9 @@ describe User, :type => :model do
     it { should have_db_column(:confirmation_token).of_type(:string).with_options(limit: 128) }
     it { should have_db_column(:remember_token).of_type(:string).with_options(limit: 128, null: false) }
     it { should have_db_column(:admin).of_type(:boolean).with_options(null: false, default: false) }
+    it { should have_db_column(:twitter).of_type(:string) }
+    it { should have_db_column(:website).of_type(:string) }
+    it { should have_db_column(:biography).of_type(:string) }
 
     it { should have_db_index(:email) }
     it { should have_db_index(:remember_token) }
@@ -20,6 +23,22 @@ describe User, :type => :model do
     it { should have_many(:team_memberships).with_foreign_key("member_id") }
     it { should have_many(:teams).through(:team_memberships) }
     it { should have_many(:projects) }
+  end
+
+  describe "validations" do
+    describe "website" do
+      it { should allow_value("www.example.com").for(:website) }
+      it { should allow_value("http://www.example.com").for(:website) }
+      it { should allow_value("example.com").for(:website) }
+      it { should allow_value("www.example.museum").for(:website) }
+      it { should allow_value("www.example.com#fragment").for(:website) }
+      it { should allow_value("www.example.com/subdomain").for(:website) }
+      it { should allow_value("api.subdomain.example.com").for(:website) }
+      it { should allow_value("www.example.com?par=value").for(:website) }
+      it { should allow_value("www.example.com?par1=value&par2=value").for(:website) }
+      it { should_not allow_value("spaces in url").for(:website) }
+      it { should_not allow_value("singleword").for(:website) }
+    end
   end
 
   describe "admin state" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,7 +9,7 @@ describe User, :type => :model do
     it { should have_db_column(:confirmation_token).of_type(:string).with_options(limit: 128) }
     it { should have_db_column(:remember_token).of_type(:string).with_options(limit: 128, null: false) }
     it { should have_db_column(:admin).of_type(:boolean).with_options(null: false, default: false) }
-    it { should have_db_column(:twitter).of_type(:text) }
+    it { should have_db_column(:twitter).of_type(:string) }
     it { should have_db_column(:website).of_type(:text) }
     it { should have_db_column(:biography).of_type(:text) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,9 +9,9 @@ describe User, :type => :model do
     it { should have_db_column(:confirmation_token).of_type(:string).with_options(limit: 128) }
     it { should have_db_column(:remember_token).of_type(:string).with_options(limit: 128, null: false) }
     it { should have_db_column(:admin).of_type(:boolean).with_options(null: false, default: false) }
-    it { should have_db_column(:twitter).of_type(:string) }
-    it { should have_db_column(:website).of_type(:string) }
-    it { should have_db_column(:biography).of_type(:string) }
+    it { should have_db_column(:twitter).of_type(:text) }
+    it { should have_db_column(:website).of_type(:text) }
+    it { should have_db_column(:biography).of_type(:text) }
 
     it { should have_db_index(:email) }
     it { should have_db_index(:remember_token) }

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+describe UserSerializer, :type => :serializer do
+
+  context "individual resource representation" do
+    let(:resource) {
+      create(:user,
+        email: "user@mail.com",
+        username: "user",
+        website: "example.com",
+        twitter: "@user",
+        biography: "Lorem ipsum")
+    }
+
+    let(:serializer) { UserSerializer.new(resource) }
+    let(:serialization) { ActiveModel::Serializer::Adapter.create(serializer) }
+
+    context "root" do
+      subject do
+        JSON.parse(serialization.to_json)['data']
+      end
+
+      it "has an attributes object" do
+        expect(subject["attributes"]).not_to be nil
+      end
+
+      it "has an id" do
+        expect(subject["id"]).to eq resource.id.to_s
+      end
+
+      it "has a type set to `users`" do
+        expect(subject["type"]).to eq "users"
+      end
+    end
+
+    context 'attributes' do
+      subject do
+        JSON.parse(serialization.to_json)['data']['attributes']
+      end
+
+      it "has an 'email'" do
+        expect(subject["email"]).to eq resource.email
+      end
+
+      it "has a 'username'" do
+        expect(subject["username"]).to eq resource.username
+      end
+
+      it "has a 'twitter'" do
+        expect(subject["twitter"]).to eq resource.twitter
+      end
+
+      it "has a 'website'" do
+        expect(subject["website"]).to eq resource.website
+      end
+
+      it "has a 'biography'" do
+        expect(subject["biography"]).to eq resource.biography
+      end
+    end
+
+    context "relationships" do
+      subject do
+        JSON.parse(serialization.to_json)["data"]["relationships"]
+      end
+
+      it "should be empty" do
+        expect(subject).to be_nil
+      end
+    end
+
+    context "included" do
+      subject do
+        JSON.parse(serialization.to_json)["included"]
+      end
+
+      it "should be empty" do
+        expect(subject).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Will close #30, #31 and #32 when merged.

Most resources I found online suggest using URI::regexp to test for validity of an URL; but that expression requires the protocol to be specified, so I rolled my own, based on various others I've found. The specs in the user model ensure which formats we support or explicitly do not support.
