### PR TITLE
Added models for posts and comments

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,4 @@
+class Comment < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :post
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,17 @@
+class Post < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :project
+  has_many :comments
+
+  enum status: {
+    open: "open",
+    closed: "closed"
+  }
+
+  enum type: {
+    idea: "idea",
+    progress: "progress",
+    task: "task",
+    issue: "issue"
+  }
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,3 +1,4 @@
 class Project < ActiveRecord::Base
   belongs_to :owner, polymorphic: true
+  has_many :posts
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ActiveRecord::Base
   has_many :team_memberships, foreign_key: "member_id"
   has_many :teams, through: :team_memberships
   has_many :projects, as: :owner
+  has_many :posts
+  has_many :comments
 
   validates :username, presence: { message: "can't be blank" }
   validates :username, uniqueness: { case_sensitive: false }

--- a/db/migrate/20151124130003_create_posts.rb
+++ b/db/migrate/20151124130003_create_posts.rb
@@ -1,0 +1,15 @@
+class CreatePosts < ActiveRecord::Migration
+  def change
+    create_table :posts do |t|
+      t.string :status, default: "open"
+      t.string :type, default: "task"
+      t.string :title, null: false
+      t.text :body
+
+      t.belongs_to :user
+      t.belongs_to :project
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20151124130007_create_comments.rb
+++ b/db/migrate/20151124130007_create_comments.rb
@@ -1,0 +1,12 @@
+class CreateComments < ActiveRecord::Migration
+  def change
+    create_table :comments do |t|
+      t.text :body
+
+      t.belongs_to :user
+      t.belongs_to :post
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151119113429) do
+ActiveRecord::Schema.define(version: 20151124130007) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "comments", force: :cascade do |t|
+    t.text     "body"
+    t.integer  "user_id"
+    t.integer  "post_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "oauth_access_grants", force: :cascade do |t|
     t.integer  "resource_owner_id", null: false
@@ -70,6 +78,17 @@ ActiveRecord::Schema.define(version: 20151119113429) do
     t.string   "name",       null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "posts", force: :cascade do |t|
+    t.string   "status",     default: "open"
+    t.string   "type",       default: "task"
+    t.string   "title",                       null: false
+    t.text     "body"
+    t.integer  "user_id"
+    t.integer  "project_id"
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
   end
 
   create_table "projects", force: :cascade do |t|

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe Comment, :type => :model do
+  describe "schema" do
+    it { should have_db_column(:body).of_type(:text) }
+    it { should have_db_column(:post_id).of_type(:integer) }
+    it { should have_db_column(:user_id).of_type(:integer) }
+    it { should have_db_column(:updated_at) }
+    it { should have_db_column(:created_at) }
+  end
+
+  describe "relationships" do
+    it { should belong_to(:post) }
+    it { should belong_to(:user) }
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe Post, :type => :model do
+  describe "schema" do
+    it { should have_db_column(:status).of_type(:string) }
+    it { should have_db_column(:type).of_type(:string) }
+    it { should have_db_column(:title).of_type(:string) }
+    it { should have_db_column(:body).of_type(:text) }
+    it { should have_db_column(:project_id).of_type(:integer) }
+    it { should have_db_column(:user_id).of_type(:integer) }
+    it { should have_db_column(:updated_at) }
+    it { should have_db_column(:created_at) }
+  end
+
+  describe "relationships" do
+    it { should have_many(:comments) }
+    it { should belong_to(:project) }
+    it { should belong_to(:user) }
+  end
+
+  describe "behavior" do
+    it { should define_enum_for(:status).with({ open: "open", closed: "closed" }) }
+    it { should define_enum_for(:type).with({ idea: "idea", progress: "progress", task: "task", issue: "issue" }) }
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -8,6 +8,7 @@ describe Project, :type => :model do
 
   describe "relationships" do
     it { should belong_to(:owner) }
+    it { should have_many(:posts) }
   end
 
   describe "ownership" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -20,6 +20,8 @@ describe User, :type => :model do
     it { should have_many(:team_memberships).with_foreign_key("member_id") }
     it { should have_many(:teams).through(:team_memberships) }
     it { should have_many(:projects) }
+    it { should have_many(:posts) }
+    it { should have_many(:comments) }
   end
 
   describe "admin state" do


### PR DESCRIPTION
Closes #15 and #23 

A bunch of tasks can't really get started until this is merged. 
#15 had no mention of a post body, but I'm guessing we wither want that, or we want to have each post immediately be created with at least one comment. I think the first approach (with post body) would be simpler, but the other is an option as well.
