### PR TITLE
Add GET endpoint for individual and list of projects

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,0 +1,10 @@
+class ProjectsController < ApplicationController
+  def index
+    render json: Project.all
+  end
+
+  def show
+    project = Project.find(params[:id])
+    render json: project
+  end
+end

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -1,0 +1,3 @@
+class ProjectSerializer < ActiveModel::Serializer
+  attributes :id, :title, :description
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,5 +14,7 @@ Rails.application.routes.draw do
     resource :users, only: [:forgot_password] do
       post :forgot_password
     end
+
+    resources :projects, only: [:show, :index]
   end
 end

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+describe "Projects API" do
+
+  context "GET /projects" do
+    before do
+      create_list(:project, 10)
+    end
+
+    it "returns a list of projects" do
+      get "#{host}/projects"
+
+      expect(last_response.status).to eq 200
+      expect(json.data.length).to eq 10
+      expect(json.data.all? { |item| item.type == "projects" }).to be true
+    end
+  end
+
+  context "GET /projects/:id" do
+    before do
+      create(:project, id: 1, title: "Project", description: "Description")
+    end
+
+    it "returns the specified project" do
+      get "#{host}/projects/1", {}
+      expect(last_response.status).to eq 200
+
+      expect(json.data.id).to eq "1"
+      expect(json.data.type).to eq "projects"
+
+      attributes = json.data.attributes
+      expect(attributes.title).to eq "Project"
+      expect(attributes.description).to eq "Description"
+    end
+  end
+end

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+describe ProjectSerializer, :type => :serializer do
+
+  context "individual resource representation" do
+    let(:resource) {
+      create(:project,
+        title: "Project title",
+        description: "Poject description")
+    }
+
+    let(:serializer) { ProjectSerializer.new(resource) }
+    let(:serialization) { ActiveModel::Serializer::Adapter.create(serializer) }
+
+    context "root" do
+      subject do
+        JSON.parse(serialization.to_json)["data"]
+      end
+
+      it "has an attributes object" do
+        expect(subject["attributes"]).not_to be nil
+      end
+
+      it "has an id" do
+        expect(subject["id"]).not_to be nil
+      end
+
+      it "has a type set to 'projects'" do
+        expect(subject["type"]).to eq "projects"
+      end
+    end
+
+    context "attributes" do
+
+      subject do
+        JSON.parse(serialization.to_json)["data"]["attributes"]
+      end
+
+      it "has a 'title'" do
+        expect(subject["title"]).to eql resource.title
+      end
+
+      it "has a 'description'" do
+        expect(subject["description"]).to eql resource.description
+      end
+    end
+
+    context "relationships" do
+      subject do
+        JSON.parse(serialization.to_json)["data"]["relationships"]
+      end
+
+      it "should be empty" do
+        expect(subject).to be_nil
+      end
+    end
+
+    context "included" do
+      subject do
+        JSON.parse(serialization.to_json)["included"]
+      end
+
+      it "should be empty" do
+        expect(subject).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes ##10, #11 when merged. Possibly #9 to, but depends.

I'm marking this as awaiting review because it's mergeable, but there are some things that could be done either via this PR, or in a separate PR
- [ ] Project should also have an icon. Since that involves uploads, I'm guessing we want to handle that somehow, via s3/cloudfront/just local uploads? This feels like something worthy of a PR of its own.
- [ ] Not sure which relationships to list by default and if I should include records for those relationships. Right now, the serializer only exposes the attributes (title, description, id).
