### PR TITLE
Implemented bullet, fixed existing n+1 queries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,11 +25,13 @@ gem 'sidekiq'
 
 group :development, :test do
   gem 'dotenv-rails'
-  
+
   gem 'pry-rails'
   gem 'pry'
   gem 'pry-nav'
   gem 'pry-stack_explorer'
+
+  gem 'bullet'
 
   gem 'rspec-rails', '~> 3.0'
   gem 'rspec-sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,9 @@ GEM
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
+    bullet (4.14.10)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.9.0)
     cancancan (1.13.1)
     clearance (1.12.0)
       bcrypt
@@ -211,6 +214,7 @@ GEM
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    uniform_notifier (1.9.0)
 
 PLATFORMS
   ruby
@@ -218,6 +222,7 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers!
   aws-sdk
+  bullet
   cancancan (~> 1.10)
   clearance
   doorkeeper

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,13 +3,13 @@ class PostsController < ApplicationController
   before_action :doorkeeper_authorize!, only: [:create]
 
   def index
-    posts = Post.all
+    posts = Post.all.includes [:comments, :user, :project]
     render json: posts
   end
 
   def show
-    post = Post.find(params[:id])
-    render json: post, include: ["comments"]
+    post = Post.includes(comments: [:user]).find(params[:id])
+    render json: post, include: [:comments]
   end
 
   def create

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,7 +17,7 @@ class UsersController < ApplicationController
   end
 
   def show
-    user = User.find(params[:id])
+    user = User.includes(skills: [:skill_category]).find(params[:id])
     render json: user, include: ["skills"]
   end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,4 +38,9 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+  end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,4 +41,9 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   Paperclip::Attachment.default_options[:path] = "#{Rails.root}/spec/test_files/:class/:id_partition/:style.:extension"
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.raise = true # raise an error if n+1 query occurs
+  end
 end


### PR DESCRIPTION
Closes #62 
# Implementation

The setup is as follows
### In `:development`
- Bullet is enabled
- Logs to `logs/bullet.log`
### In `:test`
- Bullet is enabled
- Doesn't log anywhere
- Raises error to console, causing the spec creating the n+1 query to fail
- Shows a stack trace so we can easily find where it's happening
### In `:production`
- Bullet is not enabled
## Notes

Existing n+1 queries have been fixed. 

Depending on merge order for other active PRs, specs might start failing (here if we merge other active PRs before this one, or in the other active PRs, if we merge this one first).
