### PR TITLE
Posts pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,9 +23,11 @@ gem 'aws-sdk'
 
 gem 'sidekiq'
 
+gem 'kaminari'
+
 group :development, :test do
   gem 'dotenv-rails'
-  
+
   gem 'pry-rails'
   gem 'pry'
   gem 'pry-nav'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,9 @@ GEM
     jmespath (1.1.3)
     json (1.8.3)
     jwt (1.5.2)
+    kaminari (0.16.3)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -225,6 +228,7 @@ DEPENDENCIES
   factory_girl_rails (~> 4.0)
   fakeredis
   hashie
+  kaminari
   oauth2
   paperclip
   pg

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,6 +32,10 @@ class ApplicationController < ActionController::API
     params.fetch(:page, {}).fetch(:number, 1).to_i
   end
 
+  def meta_for collection
+    { total: collection.count }
+  end
+
   def record_attributes
     params.fetch(:data, {}).fetch(:attributes, {})
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,6 +24,14 @@ class ApplicationController < ActionController::API
     current_resource_owner
   end
 
+  def page_size
+    params.fetch(:page, {}).fetch(:size, 10).to_i
+  end
+
+  def page_number
+    params.fetch(:page, {}).fetch(:number, 1).to_i
+  end
+
   def record_attributes
     params.fetch(:data, {}).fetch(:attributes, {})
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,8 +32,13 @@ class ApplicationController < ActionController::API
     params.fetch(:page, {}).fetch(:number, 1).to_i
   end
 
-  def meta_for collection
-    { total: collection.count }
+  def meta_for object
+    return {
+      total_records: object.count,
+      total_pages: (object.count.to_f / page_size).ceil,
+      page_size: page_size,
+      current_page: page_number
+    }
   end
 
   def record_attributes

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,7 +4,7 @@ class PostsController < ApplicationController
 
   def index
     posts = Post.page(page_number).per(page_size)
-    render json: posts
+    render json: posts, meta: meta_for(Post)
   end
 
   def show

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,7 @@ class PostsController < ApplicationController
   before_action :doorkeeper_authorize!, only: [:create]
 
   def index
-    posts = Post.all
+    posts = retrieve_page_for Post
     render json: posts
   end
 
@@ -23,6 +23,22 @@ class PostsController < ApplicationController
   end
 
   private
+    def retrieve_page_for collection
+      collection.limit(page_size).offset(offset)
+    end
+
+    def page_size
+      params.fetch(:page, {}).fetch(:size, 10).to_i
+    end
+
+    def page_number
+      params.fetch(:page, {}).fetch(:number, 0).to_i
+    end
+
+    def offset
+      page_size * page_number
+    end
+
     def create_params
       record_attributes.permit(:body, :title, :post_type).merge(relationships)
     end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,7 @@ class PostsController < ApplicationController
   before_action :doorkeeper_authorize!, only: [:create]
 
   def index
-    posts = retrieve_page_for Post
+    posts = Post.page(page_number).per(page_size)
     render json: posts
   end
 
@@ -23,21 +23,6 @@ class PostsController < ApplicationController
   end
 
   private
-    def retrieve_page_for collection
-      collection.limit(page_size).offset(offset)
-    end
-
-    def page_size
-      params.fetch(:page, {}).fetch(:size, 10).to_i
-    end
-
-    def page_number
-      params.fetch(:page, {}).fetch(:number, 0).to_i
-    end
-
-    def offset
-      page_size * page_number
-    end
 
     def create_params
       record_attributes.permit(:body, :title, :post_type).merge(relationships)

--- a/spec/requests/api/posts_spec.rb
+++ b/spec/requests/api/posts_spec.rb
@@ -39,9 +39,12 @@ describe "Posts API" do
     end
 
     it "renders a meta in the response" do
-      get "#{host}/posts"
+      get "#{host}/posts", { page: { number: 2, size: 5 } }
       expect(json.meta).not_to be_nil
-      expect(json.meta.total).to eq 13
+      expect(json.meta.total_records).to eq 13
+      expect(json.meta.total_pages).to eq 3
+      expect(json.meta.page_size).to eq 5
+      expect(json.meta.current_page).to eq 2
     end
   end
 

--- a/spec/requests/api/posts_spec.rb
+++ b/spec/requests/api/posts_spec.rb
@@ -15,17 +15,27 @@ describe "Posts API" do
     end
 
     it "accepts different page numbers" do
-      get "#{host}/posts", { page: { number: 0, size: 5 }}
+      get "#{host}/posts", { page: { number: 1, size: 5 }}
       expect(json.data.length).to eq 5
-      get "#{host}/posts", { page: { number: 2, size: 3 }}
+      get "#{host}/posts", { page: { number: 3, size: 3 }}
       expect(json.data.length).to eq 3
     end
 
     it "accepts different page sizes" do
-      get "#{host}/posts", { page: { number: 0, size: 3 }}
+      get "#{host}/posts", { page: { number: 1, size: 3 }}
       expect(json.data.length).to eq 3
-      get "#{host}/posts", { page: { number: 0, size: 4 }}
+      get "#{host}/posts", { page: { number: 1, size: 4 }}
       expect(json.data.length).to eq 4
+    end
+
+    it "renders links in the response" do
+      get "#{host}/posts", { page: { number: 2, size: 5 } }
+      expect(json.links).not_to be_nil
+      expect(json.links.self).not_to be_nil
+      expect(json.links.first).not_to be_nil
+      expect(json.links.prev).not_to be_nil
+      expect(json.links.last).not_to be_nil
+      expect(json.links.last).not_to be_nil
     end
   end
 

--- a/spec/requests/api/posts_spec.rb
+++ b/spec/requests/api/posts_spec.rb
@@ -4,15 +4,28 @@ describe "Posts API" do
 
   context "GET /posts" do
     before do
-      create_list(:post, 10)
+      create_list(:post, 13)
     end
 
-    it "returns a list of posts" do
+    it "returns the first page of 10 records of no page number or size is specified" do
       get "#{host}/posts"
-
       expect(last_response.status).to eq 200
       expect(json.data.length).to eq 10
       expect(json.data.all? { |item| item.type == "posts" }).to be true
+    end
+
+    it "accepts different page numbers" do
+      get "#{host}/posts", { page: { number: 0, size: 5 }}
+      expect(json.data.length).to eq 5
+      get "#{host}/posts", { page: { number: 2, size: 3 }}
+      expect(json.data.length).to eq 3
+    end
+
+    it "accepts different page sizes" do
+      get "#{host}/posts", { page: { number: 0, size: 3 }}
+      expect(json.data.length).to eq 3
+      get "#{host}/posts", { page: { number: 0, size: 4 }}
+      expect(json.data.length).to eq 4
     end
   end
 

--- a/spec/requests/api/posts_spec.rb
+++ b/spec/requests/api/posts_spec.rb
@@ -37,6 +37,12 @@ describe "Posts API" do
       expect(json.links.last).not_to be_nil
       expect(json.links.last).not_to be_nil
     end
+
+    it "renders a meta in the response" do
+      get "#{host}/posts"
+      expect(json.meta).not_to be_nil
+      expect(json.meta.total).to eq 13
+    end
   end
 
   context "GET /posts/:id" do


### PR DESCRIPTION
Closes #18 
# Implementation

Two new methods defined on the application controller level:

``` Ruby

def page_size
  params.fetch(:page, {}).fetch(:size, 10).to_i
end

def page_number
  params.fetch(:page, {}).fetch(:number, 1).to_i
end

```

We then use the `Kaminari` gem, which is supported by AMS out of the box and makes AMS add a `links` object to the `json` response.

``` Ruby
def index
  posts = Post.page(page_number).per(page_size)
  render json: posts
end
```

It's as straightforward as that.

Kaminari's page numbers are 1-based, not 0-based, so the default page is 1, while the default page size is 10. We might want to move this to a config of some sort, but Kaminari also supports several other ways to configure defaults, so I delayed that until there's a need and we figure out which approach is best for us.
# Response

Response will now include a `links` object, in the format 

``` JavaScript
{
  self: "link to current page",
  first: "link to first page"
  prev: "link to previous page, doesn't exist if current is first",
  next: "link to next page, doesn't exist if current is last",
  last: "link to last page"
}
```

It will also include a `meta` object, with the format

``` Javascript
{
  total_pages: "total number of pages in the current page size",
  total_records: "total number of records in general",
  current_page: "page number specified in the request for the current response",
  page_size: "page size specified in the request for the current response"
}
```
