### PR TITLE
Add markdown to posts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,8 @@ gem 'sidekiq'
 
 gem 'kaminari'
 
+gem 'redcarpet'
+
 group :development, :test do
   gem 'dotenv-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
+    redcarpet (3.3.3)
     redis (3.2.2)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
@@ -243,6 +244,7 @@ DEPENDENCIES
   pry-stack_explorer
   rails (= 4.2.5)
   rails-api
+  redcarpet
   rspec-rails (~> 3.0)
   rspec-sidekiq
   seed-fu

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -25,7 +25,7 @@ class PostsController < ApplicationController
   private
 
     def create_params
-      record_attributes.permit(:body, :title, :post_type).merge(relationships)
+      record_attributes.permit(:markdown, :title, :post_type).merge(relationships)
     end
 
     def project_id

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -10,7 +10,7 @@ class Post < ActiveRecord::Base
   validates_presence_of :body
   validates_presence_of :markdown
 
-  before_save :render_markdown_to_body
+  before_validation :render_markdown_to_body
 
   enum status: {
     open: "open",
@@ -31,8 +31,10 @@ class Post < ActiveRecord::Base
   private
 
     def render_markdown_to_body
-      html = parser.render(markdown)
-      self.body = html
+      if markdown.present?
+        html = parser.render(markdown)
+        self.body = html
+      end
     end
 
     def parser

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -8,6 +8,9 @@ class Post < ActiveRecord::Base
   validates_presence_of :user
   validates_presence_of :title
   validates_presence_of :body
+  validates_presence_of :markdown
+
+  before_save :render_markdown_to_body
 
   enum status: {
     open: "open",
@@ -24,4 +27,19 @@ class Post < ActiveRecord::Base
   def likes_count
     self.post_likes_count
   end
+
+  private
+
+    def render_markdown_to_body
+      html = parser.render(markdown)
+      self.body = html
+    end
+
+    def parser
+      @parser ||= Redcarpet::Markdown.new(renderer, extensions = {})
+    end
+
+    def renderer
+      @renderer ||= Redcarpet::Render::HTML.new(render_options = {})
+    end
 end

--- a/app/serializers/post_like_serializer.rb
+++ b/app/serializers/post_like_serializer.rb
@@ -1,4 +1,4 @@
 class PostLikeSerializer < ActiveModel::Serializer
   belongs_to :user
-  belongs_to :post
+  belongs_to :post, serializer: PostSerializerWithoutIncludes
 end

--- a/app/serializers/post_serializer_without_includes.rb
+++ b/app/serializers/post_serializer_without_includes.rb
@@ -1,0 +1,3 @@
+class PostSerializerWithoutIncludes < ActiveModel::Serializer
+  attributes :id, :title, :body, :status, :post_type, :likes_count
+end

--- a/db/migrate/20151130204153_add_markdown_to_posts.rb
+++ b/db/migrate/20151130204153_add_markdown_to_posts.rb
@@ -1,0 +1,5 @@
+class AddMarkdownToPosts < ActiveRecord::Migration
+  def change
+    add_column :posts, :markdown, :text, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151130085255) do
+ActiveRecord::Schema.define(version: 20151130204153) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -97,6 +97,7 @@ ActiveRecord::Schema.define(version: 20151130085255) do
     t.datetime "created_at",                        null: false
     t.datetime "updated_at",                        null: false
     t.integer  "post_likes_count", default: 0
+    t.text     "markdown",                          null: false
   end
 
   create_table "projects", force: :cascade do |t|

--- a/spec/factories/post_factory.rb
+++ b/spec/factories/post_factory.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
   factory :post do
     sequence(:title) { |n| "Post #{n}" }
     sequence(:body) { |n| "Post body #{n}" }
+    sequence(:markdown) { |n| "Post markdown #{n}" }
 
     association :user
     association :project

--- a/spec/factories/post_factory.rb
+++ b/spec/factories/post_factory.rb
@@ -2,7 +2,6 @@ FactoryGirl.define do
 
   factory :post do
     sequence(:title) { |n| "Post #{n}" }
-    sequence(:body) { |n| "Post body #{n}" }
     sequence(:markdown) { |n| "Post markdown #{n}" }
 
     association :user

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -6,6 +6,7 @@ describe Post, :type => :model do
     it { should have_db_column(:post_type).of_type(:string) }
     it { should have_db_column(:title).of_type(:string).with_options(null: false) }
     it { should have_db_column(:body).of_type(:text).with_options(null: false) }
+    it { should have_db_column(:markdown).of_type(:text).with_options(null: false) }
     it { should have_db_column(:project_id).of_type(:integer).with_options(null: false) }
     it { should have_db_column(:user_id).of_type(:integer).with_options(null: false) }
     it { should have_db_column(:updated_at) }
@@ -25,6 +26,7 @@ describe Post, :type => :model do
     it { should validate_presence_of(:project) }
     it { should validate_presence_of(:title) }
     it { should validate_presence_of(:body) }
+    it { should validate_presence_of(:markdown) }
   end
 
   describe "behavior" do
@@ -47,6 +49,16 @@ describe Post, :type => :model do
         create(:post_like, user: user, post: post)
         expect(post.likes_count).to eq 1
       end
+    end
+  end
+
+  describe "before_save" do
+    it "converts markdown to html for the body" do
+      post = create(:post, markdown: "# Hello World\n\nHello, world.")
+      post.save
+
+      post.reload
+      expect(post.body).to eq "<h1>Hello World</h1>\n\n<p>Hello, world.</p>\n"
     end
   end
 end

--- a/spec/requests/api/posts_spec.rb
+++ b/spec/requests/api/posts_spec.rb
@@ -115,7 +115,7 @@ describe "Posts API" do
 
       it "does not require a 'post_type' to be specified" do
         params = { data: { type: "posts",
-          attributes: { title: "Post title", markdown: "<p>Post body</p>\n" },
+          attributes: { title: "Post title", markdown: "Post body" },
           relationships: { project: { data: { id: 2 } } }
         } }
         authenticated_post "/posts", params, @token

--- a/spec/requests/api/posts_spec.rb
+++ b/spec/requests/api/posts_spec.rb
@@ -115,7 +115,7 @@ describe "Posts API" do
 
       it "does not require a 'post_type' to be specified" do
         params = { data: { type: "posts",
-          attributes: { title: "Post title", body: "Post body" },
+          attributes: { title: "Post title", markdown: "<p>Post body</p>\n" },
           relationships: { project: { data: { id: 2 } } }
         } }
         authenticated_post "/posts", params, @token
@@ -137,7 +137,7 @@ describe "Posts API" do
 
       it "ignores the 'status' parameter" do
         params = { data: { type: "posts",
-          attributes: { title: "Post title", post_type: "issue", status: "closed", body: "Post body" },
+          attributes: { title: "Post title", post_type: "issue", status: "closed", markdown: "Post body" },
           relationships: { project: { data: { id: 2 } } }
         } }
         authenticated_post "/posts", params, @token
@@ -151,17 +151,18 @@ describe "Posts API" do
           create(:project, id: 1)
           params = { data: {
             type: "posts",
-            attributes: { title: "Post title", body: "Post body", post_type: "issue" },
+            attributes: { title: "Post title", markdown: "Post body", post_type: "issue" },
             relationships: {
               project: { data: { id: 2, type: "projects" } }
             }
           }}
           authenticated_post "/posts", params, @token
         end
+
         it "creates a post" do
           post = Post.last
           expect(post.title).to eq "Post title"
-          expect(post.body).to eq "Post body"
+          expect(post.body).to eq "<p>Post body</p>\n"
           expect(post.issue?).to be true
 
           expect(post.user_id).to eq 1
@@ -171,7 +172,7 @@ describe "Posts API" do
         it "returns the created post" do
           post_attributes = json.data.attributes
           expect(post_attributes.title).to eq "Post title"
-          expect(post_attributes.body).to eq "Post body"
+          expect(post_attributes.body).to eq "<p>Post body</p>\n"
           expect(post_attributes.post_type).to eq "issue"
 
           post_relationships = json.data.relationships

--- a/spec/serializers/post_like_serializer_spec.rb
+++ b/spec/serializers/post_like_serializer_spec.rb
@@ -41,7 +41,7 @@ describe PostLikeSerializer, :type => :serializer do
         expect(subject["user"]["data"]["id"]).to eq resource.user.id.to_s
       end
 
-      it "should contain a 'post' relationship" do
+      it "should contain a 'post' relationship without comments" do
         expect(subject["post"]).not_to be_nil
         expect(subject["post"]["data"]["type"]).to eq "posts"
         expect(subject["post"]["data"]["id"]).to eq resource.post.id.to_s

--- a/spec/serializers/post_serializer_without_includes_spec.rb
+++ b/spec/serializers/post_serializer_without_includes_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+describe PostSerializerWithoutIncludes, :type => :serializer do
+
+  context "individual resource representation" do
+    let(:resource) {
+      post = create(:post,
+        title: "Post title",
+        user: create(:user),
+        project: create(:project))
+
+      create_list(:comment, 10, post: post)
+      post.reload
+    }
+
+    let(:serializer) { PostSerializerWithoutIncludes.new(resource) }
+    let(:serialization) { ActiveModel::Serializer::Adapter.create(serializer) }
+
+    context "root" do
+      subject do
+        JSON.parse(serialization.to_json)["data"]
+      end
+
+      it "has an attributes object" do
+        expect(subject["attributes"]).not_to be nil
+      end
+
+      it "has an id" do
+        expect(subject["id"]).not_to be nil
+      end
+
+      it "has a type set to 'posts'" do
+        expect(subject["type"]).to eq "posts"
+      end
+    end
+
+    context "attributes" do
+      subject do
+        JSON.parse(serialization.to_json)["data"]["attributes"]
+      end
+
+      it "has a 'title'" do
+        expect(subject["title"]).to eql resource.title
+      end
+
+      it "has a 'status'" do
+        expect(subject["status"]).to eql resource.status
+      end
+
+      it "has a 'post_type'" do
+        expect(subject["post_type"]).to eql resource.post_type
+      end
+
+      it "has a 'likes_count'" do
+        expect(subject["likes_count"]).to eql resource.likes_count
+      end
+    end
+
+    context "relationships" do
+      subject do
+        JSON.parse(serialization.to_json)["data"]["relationships"]
+      end
+
+      it "should be nil" do
+        expect(subject).to be_nil
+      end
+    end
+
+    context "included" do
+      context "when not including anything" do
+        subject do
+          JSON.parse(serialization.to_json)["included"]
+        end
+
+        it "should be empty" do
+          expect(subject).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a `markdown` field to the `Post`. A `Post` will take this in on `create` and in a `before_validation` hook it will render the markdown into HTML using `Redcarpet`, and then save that as the `body` which gets rendered out from the API.
