### PR TITLE
Facebook authentication (with no special actions)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,8 @@ gem 'sidekiq'
 
 gem 'kaminari'
 
+gem 'koala'
+
 gem 'redcarpet'
 
 group :development, :test do
@@ -49,6 +51,9 @@ end
 group :test do
   gem 'factory_girl_rails', '~> 4.0'
   gem 'shoulda-matchers'
+
+  gem 'vcr'
+  gem 'webmock'
 
   gem 'oauth2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.3.8)
     arel (6.0.3)
     aws-sdk (2.2.3)
       aws-sdk-resources (= 2.2.3)
@@ -70,6 +71,8 @@ GEM
     coderay (1.1.0)
     concurrent-ruby (1.0.0)
     connection_pool (2.2.0)
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     doorkeeper (3.0.1)
@@ -92,6 +95,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
+    hashdiff (0.2.2)
     hashie (3.4.3)
     i18n (0.7.0)
     jmespath (1.1.3)
@@ -100,6 +104,10 @@ GEM
     kaminari (0.16.3)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
+    koala (2.2.0)
+      addressable
+      faraday
+      multi_json
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -197,6 +205,7 @@ GEM
       rspec (~> 3.0, >= 3.0.0)
       sidekiq (>= 2.4.0)
     rspec-support (3.4.1)
+    safe_yaml (1.0.4)
     seed-fu (2.3.5)
       activerecord (>= 3.1, < 4.3)
       activesupport (>= 3.1, < 4.3)
@@ -220,6 +229,11 @@ GEM
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uniform_notifier (1.9.0)
+    vcr (3.0.0)
+    webmock (1.22.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -235,6 +249,7 @@ DEPENDENCIES
   fakeredis
   hashie
   kaminari
+  koala
   oauth2
   paperclip
   pg
@@ -252,6 +267,8 @@ DEPENDENCIES
   shoulda-matchers
   sidekiq
   spring
+  vcr
+  webmock
 
 BUNDLED WITH
    1.10.6

--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -1,6 +1,11 @@
 class TokensController < Doorkeeper::TokensController
   def create
-    user_id = authenticate_with_credentials
+
+    if signing_in_with_facebook?
+      user_id = authenticate_with_facebook
+    else
+      user_id = authenticate_with_credentials
+    end
 
   rescue Doorkeeper::Errors::DoorkeeperError,
          Doorkeeper::Errors::InvalidGrantReuse,
@@ -8,11 +13,14 @@ class TokensController < Doorkeeper::TokensController
          Koala::Facebook::AuthenticationError,
          ActiveRecord::RecordNotFound => e
 
-    Raven.capture_exception e
     render_error e
   end
 
   private
+
+    def signing_in_with_facebook?
+      params[:username] == "facebook"
+    end
 
     def render_error(error)
       error_hash = ErrorSerializer.serialize(error)
@@ -28,14 +36,44 @@ class TokensController < Doorkeeper::TokensController
       end
     end
 
-    def handle_authentication_successful(response)
-      self.headers.merge! response.headers
-      self.status = response.status
+      def handle_authentication_successful(response)
+        self.headers.merge! response.headers
+        self.status = response.status
 
-      user_id = response.try(:token).try(:resource_owner_id)
-      body = response.body.merge('user_id' => user_id)
-      self.response_body = body.to_json
+        user_id = response.try(:token).try(:resource_owner_id)
+        body = response.body.merge('user_id' => user_id)
+        self.response_body = body.to_json
+
+        return user_id
+      end
+
+    def authenticate_with_facebook
+      user_id = get_user_id_from_facebook_information
+      token_data = generate_token_data(user_id)
+      render json: token_data.to_json, status: :ok
 
       return user_id
     end
+
+      def get_user_id_from_facebook_information
+        facebook_access_token = params[:password]
+        graph = Koala::Facebook::API.new(facebook_access_token, ENV["FACEBOOK_APP_SECRET"])
+        facebook_user = graph.get_object("me", { fields: ['email', 'first_name', 'last_name']})
+
+        User.find_by!(facebook_id: facebook_user["id"]).id
+      end
+
+      def generate_token_data(user_id)
+        doorkeeper_access_token = Doorkeeper::AccessToken.create!({
+          application_id: nil,
+          resource_owner_id: user_id,
+          expires_in: 7200})
+
+        return {
+          access_token: doorkeeper_access_token.token,
+          token_type: 'bearer',
+          expires_in: doorkeeper_access_token.expires_in,
+          user_id: user_id.to_s
+        }
+      end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -85,7 +85,7 @@ class UsersController < ApplicationController
     end
 
     def create_params
-      record_attributes.permit(:email, :username, :password)
+      record_attributes.permit(:email, :username, :password, :facebook_id, :facebook_access_token)
     end
 
     def update_params

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -4,6 +4,9 @@ class ErrorSerializer
     error_hash = serialize_doorkeeper_oauth_error_response(error) if error.class == Doorkeeper::OAuth::ErrorResponse
     error_hash = serialize_validation_errors(error) if error.class == ActiveModel::Errors
     error_hash = serialize_pundit_not_authorized_error(error) if error.class == Pundit::NotAuthorizedError
+    error_hash = serialize_facebook_authentication_error(error) if error.class == Koala::Facebook::AuthenticationError
+    error_hash = serialize_record_not_found_error(error) if error.class == ActiveRecord::RecordNotFound
+
     { errors: Array.wrap(error_hash) }
   end
 
@@ -43,5 +46,23 @@ class ErrorSerializer
           { id: "VALIDATION_ERROR", title: "#{k.capitalize} error", detail: msg, status: 422 }
         end
       end.flatten
+    end
+
+    def self.serialize_facebook_authentication_error(error)
+      return {
+        id: "FACEBOOK_AUTHENTICATION_ERROR",
+        title: "Facebook authentication error",
+        detail: error.fb_error_message,
+        status: error.http_status
+      }
+    end
+
+    def self.serialize_record_not_found_error(error)
+      return {
+        id: "RECORD_NOT_FOUND",
+        title: "Record not found",
+        detail: error.message,
+        status: 404
+      }
     end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,5 +1,5 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :email, :username, :twitter, :biography, :website
+  attributes :id, :email, :username, :twitter, :biography, :website, :facebook_id, :facebook_access_token
 
   has_many :skills
 end

--- a/db/migrate/20151202083431_add_facebook_to_users.rb
+++ b/db/migrate/20151202083431_add_facebook_to_users.rb
@@ -1,0 +1,6 @@
+class AddFacebookToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :facebook_id, :string
+    add_column :users, :facebook_access_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151201175725) do
+ActiveRecord::Schema.define(version: 20151202083431) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,14 @@ ActiveRecord::Schema.define(version: 20151201175725) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text     "markdown",   null: false
+  end
+
+  create_table "contributors", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "project_id"
+    t.string   "status",     default: "pending", null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
   end
 
   create_table "oauth_access_grants", force: :cascade do |t|
@@ -155,17 +163,19 @@ ActiveRecord::Schema.define(version: 20151201175725) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.datetime "created_at",                                     null: false
-    t.datetime "updated_at",                                     null: false
-    t.string   "email",                                          null: false
-    t.string   "encrypted_password", limit: 128,                 null: false
-    t.string   "confirmation_token", limit: 128
-    t.string   "remember_token",     limit: 128,                 null: false
+    t.datetime "created_at",                                        null: false
+    t.datetime "updated_at",                                        null: false
+    t.string   "email",                                             null: false
+    t.string   "encrypted_password",    limit: 128,                 null: false
+    t.string   "confirmation_token",    limit: 128
+    t.string   "remember_token",        limit: 128,                 null: false
     t.string   "username"
-    t.boolean  "admin",                          default: false, null: false
+    t.boolean  "admin",                             default: false, null: false
     t.text     "website"
     t.string   "twitter"
     t.text     "biography"
+    t.string   "facebook_id"
+    t.string   "facebook_access_token"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", using: :btree

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,6 +12,8 @@ describe User, :type => :model do
     it { should have_db_column(:twitter).of_type(:string) }
     it { should have_db_column(:website).of_type(:text) }
     it { should have_db_column(:biography).of_type(:text) }
+    it { should have_db_column(:facebook_id).of_type(:string) }
+    it { should have_db_column(:facebook_access_token).of_type(:string) }
 
     it { should have_db_index(:email) }
     it { should have_db_index(:remember_token) }

--- a/spec/requests/api/tokens_spec.rb
+++ b/spec/requests/api/tokens_spec.rb
@@ -41,5 +41,67 @@ describe "Tokens API" do
         expect(json).to be_a_valid_json_api_error.with_id "INVALID_GRANT"
       end
     end
+
+    context "with a facebook_auth_code" do
+
+      context "when facebook user doesn't exist", vcr: { cassette_name: 'requests/api/tokens/facebook_user_not_found' } do
+        it "fails with 400" do
+          post "#{host}/oauth/token", {
+            grant_type: "password",
+            username: 'facebook',
+            password: 'non-existant-token'
+          }
+
+          expect(last_response.status).to eq 400
+          expect(json).to be_a_valid_json_api_error.with_id "FACEBOOK_AUTHENTICATION_ERROR"
+        end
+      end
+
+      context "when facebook user does exist", vcr: { cassette_name: 'requests/api/tokens/facebook_user_found' } do
+        before do
+          oauth = Koala::Facebook::OAuth.new(ENV["FACEBOOK_APP_ID"], ENV["FACEBOOK_APP_SECRET"], ENV["FACEBOOK_REDIRECT_URL"])
+          test_users = Koala::Facebook::TestUsers.new(app_id: ENV["FACEBOOK_APP_ID"], secret: ENV["FACEBOOK_APP_SECRET"])
+          facebook_user = test_users.create(true, "email,user_friends")
+
+          short_lived_token = facebook_user["access_token"]
+          long_lived_token_info = oauth.exchange_access_token_info(short_lived_token)
+          facebook_auth_code = oauth.generate_client_code(long_lived_token_info["access_token"])
+          access_token_info = oauth.get_access_token_info(facebook_auth_code)
+
+          @facebook_access_token = access_token_info["access_token"] || JSON.parse(access_token_info.keys[0])["access_token"]
+          @facebook_id = facebook_user["id"]
+        end
+
+        context "and there's a user with facebook_id in the database" do
+          before do
+            @user = create(:user, facebook_id: @facebook_id)
+          end
+
+          it "returns a token" do
+            post "#{host}/oauth/token", {
+              grant_type: "password",
+              username: 'facebook',
+              password: @facebook_access_token
+            }
+
+            expect(last_response.status).to eq 200
+            expect(json.access_token).not_to be nil
+          end
+        end
+
+        context "and there's no user with that facebook_id in the database" do
+          it "fails with a 404" do
+            post "#{host}/oauth/token", {
+              grant_type: "password",
+              username: 'facebook',
+              password: @facebook_access_token
+            }
+
+            expect(last_response.status).to eq 404
+            expect(json).to be_a_valid_json_api_error.with_id "RECORD_NOT_FOUND"
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -129,7 +129,7 @@ describe "Users API" do
         end
 
         it "returns the created user using UserSerializer", vcr: { cassette_name: "requests/api/users/valid_facebook_request" } do
-          expect(json).to serialize_object(User.last).with(UserSerializer)
+          expect(json).to serialize_object(User.last).with(UserSerializer).with_includes("skills")
         end
 
       end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -89,19 +89,69 @@ describe "Users API" do
 
   context 'POST /users' do
 
-    it 'creates a valid user' do
-      params = { email: "josh@example.com", username: "joshsmith", password: "password" }
-      json_api_params = json_api_params_for("users", params)
+    context "when registering through Facebook" do
+      before do
+        oauth = Koala::Facebook::OAuth.new(ENV["FACEBOOK_APP_ID"], ENV["FACEBOOK_APP_SECRET"], ENV["FACEBOOK_REDIRECT_URL"])
+        test_users = Koala::Facebook::TestUsers.new(app_id: ENV["FACEBOOK_APP_ID"], secret: ENV["FACEBOOK_APP_SECRET"])
+        facebook_user = test_users.create(true, "email,user_friends")
 
-      post "#{host}/users", json_api_params
+        short_lived_token = facebook_user["access_token"]
+        long_lived_token_info = oauth.exchange_access_token_info(short_lived_token)
+        facebook_auth_code = oauth.generate_client_code(long_lived_token_info["access_token"])
+        access_token_info = oauth.get_access_token_info(facebook_auth_code)
 
-      expect(last_response.status).to eq 200
+        @facebook_access_token = access_token_info["access_token"] || JSON.parse(access_token_info.keys[0])["access_token"]
+        @facebook_id = facebook_user["id"]
+      end
 
-      user_attributes = json.data.attributes
+      context "when parameters are valid" do
+        before do
+          params = {
+            email: "josh@example.com",
+            username: "joshsmith",
+            password: "password",
+            facebook_id: @facebook_id,
+            facebook_access_token: @facebook_access_token
+          }
+          json_api_params = json_api_params_for("users", params)
+          post "#{host}/users", json_api_params
+        end
 
-      expect(user_attributes.email).to eq "josh@example.com"
-      expect(user_attributes.username).to eq "joshsmith"
-      expect(user_attributes.password).to be_nil
+        it "creates a valid user", vcr: { cassette_name: "requests/api/users/valid_facebook_request" } do
+          expect(User.last.email).to eq "josh@example.com"
+          expect(User.last.username).to eq "joshsmith"
+          expect(User.last.facebook_id).to eq @facebook_id
+          expect(User.last.facebook_access_token).to eq @facebook_access_token
+        end
+
+        it "responds with a 200", vcr: { cassette_name: "requests/api/users/valid_facebook_request" } do
+          expect(last_response.status).to eq 200
+        end
+
+        it "returns the created user using UserSerializer", vcr: { cassette_name: "requests/api/users/valid_facebook_request" } do
+          expect(json).to serialize_object(User.last).with(UserSerializer)
+        end
+
+      end
+
+    end
+
+    context "when registering directly" do
+
+      it 'creates a valid user' do
+        params = { email: "josh@example.com", username: "joshsmith", password: "password" }
+        json_api_params = json_api_params_for("users", params)
+
+        post "#{host}/users", json_api_params
+
+        expect(last_response.status).to eq 200
+
+        user_attributes = json.data.attributes
+
+        expect(user_attributes.email).to eq "josh@example.com"
+        expect(user_attributes.username).to eq "joshsmith"
+        expect(user_attributes.password).to be_nil
+      end
     end
 
     context 'with invalid data' do
@@ -139,7 +189,6 @@ describe "Users API" do
 
         expect(json.errors[0].detail).to eq "Username may only contain alphanumeric characters, underscores, or single hyphens, and cannot begin or end with a hyphen or underscore"
       end
-
     end
 
     context 'when user accounts are taken' do

--- a/spec/serializers/error_serializer_spec.rb
+++ b/spec/serializers/error_serializer_spec.rb
@@ -44,5 +44,32 @@ describe ErrorSerializer do
       expect(error[:detail]).to eq "You are not authorized to perform this action on users."
       expect(error[:status]).to eq 401
     end
+
+    it "can serialize Koala::Facebook::AuthenticationError" do
+      facebook_authentication_error = Koala::Facebook::AuthenticationError.new(400, nil, { "message" => "A message" })
+      result = ErrorSerializer.serialize(facebook_authentication_error)
+
+      expect(result[:errors]).not_to be_nil
+      expect(result[:errors].length).to eq 1
+
+      error = result[:errors].first
+      expect(error[:id]).to eq "FACEBOOK_AUTHENTICATION_ERROR"
+      expect(error[:title]).to eq "Facebook authentication error"
+      expect(error[:detail]).to eq "A message"
+      expect(error[:status]).to eq 400
+    end
+
+    it "can serialize ActiveRecord::RecordNotFound error" do
+      record_not_found_error = ActiveRecord::RecordNotFound.new("A message")
+      result = ErrorSerializer.serialize(record_not_found_error)
+      expect(result[:errors]).not_to be_nil
+      expect(result[:errors].length).to eq 1
+
+      error = result[:errors].first
+      expect(error[:id]).to eq "RECORD_NOT_FOUND"
+      expect(error[:title]).to eq "Record not found"
+      expect(error[:detail]).to eq "A message"
+      expect(error[:status]).to eq 404
+    end
   end
 end

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -9,7 +9,9 @@ describe UserSerializer, :type => :serializer do
         username: "user",
         website: "example.com",
         twitter: "@user",
-        biography: "Lorem ipsum")
+        biography: "Lorem ipsum",
+        facebook_id: "some_id",
+        facebook_access_token: "some_token")
       create_list(:user_skill, 10, user: user)
       user
     }
@@ -62,6 +64,14 @@ describe UserSerializer, :type => :serializer do
 
       it "has a 'biography'" do
         expect(subject["biography"]).to eq resource.biography
+      end
+
+      it "has a 'facebook_id'" do
+        expect(subject["facebook_id"]).to eq resource.facebook_id
+      end
+
+      it "has a 'facebook_access_token'" do
+        expect(subject["facebook_access_token"]).to eq resource.facebook_access_token
       end
     end
 

--- a/spec/support/matchers/serializer_matchers.rb
+++ b/spec/support/matchers/serializer_matchers.rb
@@ -1,0 +1,11 @@
+RSpec::Matchers.define :serialize_object do |object|
+  match do |json|
+    serializer =  @serializer_klass.new(object)
+    serialization = ActiveModel::Serializer::Adapter.create(serializer)
+    JSON.parse(serialization.to_json) == json
+  end
+
+  chain :with do |serializer_klass|
+    @serializer_klass = serializer_klass
+  end
+end

--- a/spec/support/matchers/serializer_matchers.rb
+++ b/spec/support/matchers/serializer_matchers.rb
@@ -1,11 +1,20 @@
 RSpec::Matchers.define :serialize_object do |object|
   match do |json|
     serializer =  @serializer_klass.new(object)
-    serialization = ActiveModel::Serializer::Adapter.create(serializer)
+    serialization = ActiveModel::Serializer::Adapter.create(serializer) unless includes_specified?
+    serialization = ActiveModel::Serializer::Adapter.create(serializer, include: @includes) if includes_specified?
     JSON.parse(serialization.to_json) == json
   end
 
   chain :with do |serializer_klass|
     @serializer_klass = serializer_klass
+  end
+
+  chain :with_includes do |includes|
+    @includes = Array.wrap(includes)
+  end
+
+  def includes_specified?
+    @includes.present?
   end
 end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,0 +1,14 @@
+VCR.configure do |c|
+  c.cassette_library_dir = Rails.root.join("spec", "vcr")
+  c.hook_into :webmock
+  c.configure_rspec_metadata!
+
+  # Uncomment for debugging VCR
+  # c.debug_logger = File.open("log/test.log", "w")
+
+  c.allow_http_connections_when_no_cassette = false
+
+  c.default_cassette_options = { :serialize_with => :psych }
+
+  ignore_localhost = true
+end

--- a/spec/vcr/requests/api/tokens/facebook_user_found.yml
+++ b/spec/vcr/requests/api/tokens/facebook_user_found.yml
@@ -1,0 +1,293 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://graph.facebook.com/oauth/access_token
+    body:
+      encoding: UTF-8
+      string: client_id=1125362907491067&client_secret=57b63caabfe3d1a9b568e8660d3d7d65&grant_type=client_credentials
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/plain; charset=UTF-8
+      X-Fb-Trace-Id:
+      - Hmt7okDJb/q
+      X-Fb-Rev:
+      - '2067909'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Facebook-Api-Version:
+      - v2.0
+      Expires:
+      - Sat, 01 Jan 2000 00:00:00 GMT
+      X-Fb-Debug:
+      - "+6uZDIdheBO72IDsWvPL8rnYgDV728rlGX8sGYGFXAffZ/Ipw1e36Qw7xFxd7IJz9pJ9gwHzrgx5wciwfCUrCg=="
+      Date:
+      - Wed, 02 Dec 2015 09:02:03 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '57'
+    body:
+      encoding: UTF-8
+      string: access_token=1125362907491067|BX4v-oq4_lmDeePcEA0q4XNeoVk
+    http_version: 
+  recorded_at: Wed, 02 Dec 2015 09:02:14 GMT
+- request:
+    method: post
+    uri: https://graph.facebook.com/1125362907491067/accounts/test-users
+    body:
+      encoding: UTF-8
+      string: access_token=1125362907491067%7CBX4v-oq4_lmDeePcEA0q4XNeoVk&installed=true&permissions=email%2Cuser_friends
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Fb-Trace-Id:
+      - EBW6hVz8wEP
+      X-Fb-Rev:
+      - '2067909'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Facebook-Api-Version:
+      - v2.4
+      Expires:
+      - Sat, 01 Jan 2000 00:00:00 GMT
+      X-Fb-Debug:
+      - bcJ3si9GJSqaMuTmrXWkshAapuA3Hcd5PL3/laH3e1IWD//KTHIORPIkkAVVntF4Hsdq427MbOs8QAHIfYaw7Q==
+      Date:
+      - Wed, 02 Dec 2015 09:02:09 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '415'
+    body:
+      encoding: UTF-8
+      string: '{"id":"127412320959275","access_token":"CAAPZCgvhYKvsBAO2U65uD26R8cB3cMUzLC5gvE01ft8mZB2mFvtWH9mUZATSpiAwqDYO5VA251904QNTr8F4DHUGvqqfHpvtDGKZBom4nKHZC382UPuZC6xZAPy45YcbDZA6Y9uavRKF0RAsIiIDcdFP7QQQCJD2eFTSeuFFEv9vmEbaplEaZAcQqTfYNLhwcmlUZD","login_url":"https:\/\/developers.facebook.com\/checkpoint\/test-user-login\/127412320959275\/","email":"wzkpsqk_thurnstein_1449046924\u0040tfbnw.net","password":"317343020"}'
+    http_version: 
+  recorded_at: Wed, 02 Dec 2015 09:02:20 GMT
+- request:
+    method: post
+    uri: https://graph.facebook.com/oauth/access_token
+    body:
+      encoding: UTF-8
+      string: client_id=1125362907491067&client_secret=57b63caabfe3d1a9b568e8660d3d7d65&fb_exchange_token=CAAPZCgvhYKvsBAO2U65uD26R8cB3cMUzLC5gvE01ft8mZB2mFvtWH9mUZATSpiAwqDYO5VA251904QNTr8F4DHUGvqqfHpvtDGKZBom4nKHZC382UPuZC6xZAPy45YcbDZA6Y9uavRKF0RAsIiIDcdFP7QQQCJD2eFTSeuFFEv9vmEbaplEaZAcQqTfYNLhwcmlUZD&grant_type=fb_exchange_token
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/plain; charset=UTF-8
+      X-Fb-Trace-Id:
+      - FQpSFxnVO+n
+      X-Fb-Rev:
+      - '2067909'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Facebook-Api-Version:
+      - v2.0
+      Expires:
+      - Sat, 01 Jan 2000 00:00:00 GMT
+      X-Fb-Debug:
+      - 70hZzR/HnjKZ576Uc0XDf/9vFfysMSAAbJgXZfzCfXqf8XdAlk6/Zo4fG5ItrhvNIGTO+W3QTnw3SOTHTUXtQw==
+      Date:
+      - Wed, 02 Dec 2015 09:02:10 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '227'
+    body:
+      encoding: UTF-8
+      string: access_token=CAAPZCgvhYKvsBAOsZAzImm2f8ZCuwD2sGCusQ0PtrMtuzelvbKEpBKCVIjjUhp8jhqKJQbsEdjBxpfnIOIZBjTHVxX6xWdvopnWftZAklq7n3QEvycSlSV2wZAActNp7mPMBM717qByH6nnmr6NutvZCdmLGA72UjQDTH5fN2X194t9OKdcQ6ZCgUKPvLjagwrsZD&expires=5184000
+    http_version: 
+  recorded_at: Wed, 02 Dec 2015 09:02:21 GMT
+- request:
+    method: get
+    uri: https://graph.facebook.com/oauth/client_code?access_token=CAAPZCgvhYKvsBAOsZAzImm2f8ZCuwD2sGCusQ0PtrMtuzelvbKEpBKCVIjjUhp8jhqKJQbsEdjBxpfnIOIZBjTHVxX6xWdvopnWftZAklq7n3QEvycSlSV2wZAActNp7mPMBM717qByH6nnmr6NutvZCdmLGA72UjQDTH5fN2X194t9OKdcQ6ZCgUKPvLjagwrsZD&client_id=1125362907491067&client_secret=57b63caabfe3d1a9b568e8660d3d7d65&redirect_uri=http://localhost:3000/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Fb-Trace-Id:
+      - CgOzuWK93kA
+      X-Fb-Rev:
+      - '2067909'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Facebook-Api-Version:
+      - v2.0
+      Expires:
+      - Sat, 01 Jan 2000 00:00:00 GMT
+      X-Fb-Debug:
+      - o1ludGcrgJsGzTImWh0JLmw07YeawjOQ8eY+dllUoyi/JtnxMx8iW0cEM5utr9IPnmHgNNH393jRZ6qo9SJurg==
+      Date:
+      - Wed, 02 Dec 2015 09:02:10 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '334'
+    body:
+      encoding: UTF-8
+      string: '{"code":"AQAmV5XUuwyjNT04v8IuTroD3HmA5Nv9Xvlgp8MKMt4Nnoey8ay-OFFDkR2GRbUHSds0jkQEuoLUge_jL4aVV1aw6FbXCGhwYdvbik6rOEbxWKYA-YkNsWS2w4V0Z8xSZ29y5b4WzEqMImoqTjEMbv2mEhMv2BGMOljtYD1IfWFJAL5fU3Gh2pfZ5KGcuOflGuD5jQ-qng_C8lak2gJS9mWMMZlsR3ZioyKr3gF-GDioZmAHzFvpbjoZ_x79tsld3bmz4EB5JoUUgepysqpBeWl6OqhyZf3m1oLRv1fCi4HJTCNx7yGWBbww2JTtE8wRTJI"}'
+    http_version: 
+  recorded_at: Wed, 02 Dec 2015 09:02:21 GMT
+- request:
+    method: get
+    uri: https://graph.facebook.com/oauth/access_token?client_id=1125362907491067&client_secret=57b63caabfe3d1a9b568e8660d3d7d65&code=AQAmV5XUuwyjNT04v8IuTroD3HmA5Nv9Xvlgp8MKMt4Nnoey8ay-OFFDkR2GRbUHSds0jkQEuoLUge_jL4aVV1aw6FbXCGhwYdvbik6rOEbxWKYA-YkNsWS2w4V0Z8xSZ29y5b4WzEqMImoqTjEMbv2mEhMv2BGMOljtYD1IfWFJAL5fU3Gh2pfZ5KGcuOflGuD5jQ-qng_C8lak2gJS9mWMMZlsR3ZioyKr3gF-GDioZmAHzFvpbjoZ_x79tsld3bmz4EB5JoUUgepysqpBeWl6OqhyZf3m1oLRv1fCi4HJTCNx7yGWBbww2JTtE8wRTJI&redirect_uri=http://localhost:3000/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Fb-Trace-Id:
+      - G+lGdjpISKb
+      X-Fb-Rev:
+      - '2067909'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Facebook-Api-Version:
+      - v2.0
+      Expires:
+      - Sat, 01 Jan 2000 00:00:00 GMT
+      X-Fb-Debug:
+      - p1447I6ABF+rghFj28xSh09CCf+p9Jss72opfBVrofcP7R1Szz/uw87MbrB4MJplejX8dzAsCg7pYau814syUA==
+      Date:
+      - Wed, 02 Dec 2015 09:02:11 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '266'
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"CAAPZCgvhYKvsBAEaw8DZC9mSK0oXqA8VKHCGt6cHlrJBwTNcAvInZBdJZAHU2KtOrdB0YLG1H7kfZBd4QC7vwMIrmaqs3SFjCnZAKGT6CegBJUHor9tHz7CzPVEbUk0yYNRdnKGWZBArrc3dZC76r97s7gUVPZBt6bgN1G7UnYD85hD5lfAK7e8aM","machine_id":"k7NeVnMWYq-r7m-pJNrMDkvj","expires_in":5183999}'
+    http_version: 
+  recorded_at: Wed, 02 Dec 2015 09:02:22 GMT
+- request:
+    method: get
+    uri: https://graph.facebook.com/me?access_token=CAAPZCgvhYKvsBAEaw8DZC9mSK0oXqA8VKHCGt6cHlrJBwTNcAvInZBdJZAHU2KtOrdB0YLG1H7kfZBd4QC7vwMIrmaqs3SFjCnZAKGT6CegBJUHor9tHz7CzPVEbUk0yYNRdnKGWZBArrc3dZC76r97s7gUVPZBt6bgN1G7UnYD85hD5lfAK7e8aM&appsecret_proof=c579d52ed164867bd091c69b28953abf0eecb78f6a3fa50ce0617b97754e3526&fields=email,first_name,last_name
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Fb-Trace-Id:
+      - G132rgtio/0
+      X-Fb-Rev:
+      - '2067909'
+      Etag:
+      - '"437bdd27b988a45b1e85338ae5c0b2a4c0e47458"'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Facebook-Api-Version:
+      - v2.4
+      Expires:
+      - Sat, 01 Jan 2000 00:00:00 GMT
+      X-Fb-Debug:
+      - 59RKkxS1NbxirGrLXHLGLbwnbBPf07IODJIDrB1eoe365TcNvs1iWze5y0WmdKER8UxXpy/kKtaXO3QP2xeHHQ==
+      Date:
+      - Wed, 02 Dec 2015 09:02:12 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '127'
+    body:
+      encoding: UTF-8
+      string: '{"email":"wzkpsqk_thurnstein_1449046924\u0040tfbnw.net","first_name":"Barbara","last_name":"Thurnstein","id":"127412320959275"}'
+    http_version: 
+  recorded_at: Wed, 02 Dec 2015 09:02:23 GMT
+recorded_with: VCR 3.0.0

--- a/spec/vcr/requests/api/tokens/facebook_user_found.yml
+++ b/spec/vcr/requests/api/tokens/facebook_user_found.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://graph.facebook.com/oauth/access_token
     body:
       encoding: UTF-8
-      string: client_id=1125362907491067&client_secret=57b63caabfe3d1a9b568e8660d3d7d65&grant_type=client_credentials
+      string: client_id=488082234697424&client_secret=62162fa577e11cdd671dce539d9629ca&grant_type=client_credentials
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -25,9 +25,9 @@ http_interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       X-Fb-Trace-Id:
-      - Hmt7okDJb/q
+      - CuF/jFsKSA5
       X-Fb-Rev:
-      - '2067909'
+      - '2073942'
       Pragma:
       - no-cache
       Cache-Control:
@@ -37,24 +37,24 @@ http_interactions:
       Expires:
       - Sat, 01 Jan 2000 00:00:00 GMT
       X-Fb-Debug:
-      - "+6uZDIdheBO72IDsWvPL8rnYgDV728rlGX8sGYGFXAffZ/Ipw1e36Qw7xFxd7IJz9pJ9gwHzrgx5wciwfCUrCg=="
+      - SBfYw6PiJykiTr6XHCZG3mKqVdms1Pt8FOyBSGmWvlLq4phvkGro7AC6oWnWaH9ToWvyVty86761JmqrgBCRCA==
       Date:
-      - Wed, 02 Dec 2015 09:02:03 GMT
+      - Fri, 04 Dec 2015 23:11:50 GMT
       Connection:
       - keep-alive
       Content-Length:
-      - '57'
+      - '56'
     body:
       encoding: UTF-8
-      string: access_token=1125362907491067|BX4v-oq4_lmDeePcEA0q4XNeoVk
+      string: access_token=488082234697424|3Ni5iU_mYlazCYz4FpvhnW03RZg
     http_version: 
-  recorded_at: Wed, 02 Dec 2015 09:02:14 GMT
+  recorded_at: Fri, 04 Dec 2015 23:11:50 GMT
 - request:
     method: post
-    uri: https://graph.facebook.com/1125362907491067/accounts/test-users
+    uri: https://graph.facebook.com/488082234697424/accounts/test-users
     body:
       encoding: UTF-8
-      string: access_token=1125362907491067%7CBX4v-oq4_lmDeePcEA0q4XNeoVk&installed=true&permissions=email%2Cuser_friends
+      string: access_token=488082234697424%7C3Ni5iU_mYlazCYz4FpvhnW03RZg&installed=true&permissions=email%2Cuser_friends
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -74,36 +74,36 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Fb-Trace-Id:
-      - EBW6hVz8wEP
+      - AHocu1pjLrn
       X-Fb-Rev:
-      - '2067909'
+      - '2073942'
       Pragma:
       - no-cache
       Cache-Control:
       - private, no-cache, no-store, must-revalidate
       Facebook-Api-Version:
-      - v2.4
+      - v2.5
       Expires:
       - Sat, 01 Jan 2000 00:00:00 GMT
       X-Fb-Debug:
-      - bcJ3si9GJSqaMuTmrXWkshAapuA3Hcd5PL3/laH3e1IWD//KTHIORPIkkAVVntF4Hsdq427MbOs8QAHIfYaw7Q==
+      - w8favxVIWGqfGpCBHto74kJs6kH/vSRLyqPCO8SdNlt1UxrPs9Ge84jZVbqBq+h3/cVxgwu7sVpNAK9rpgFSZQ==
       Date:
-      - Wed, 02 Dec 2015 09:02:09 GMT
+      - Fri, 04 Dec 2015 23:11:54 GMT
       Connection:
       - keep-alive
       Content-Length:
-      - '415'
+      - '420'
     body:
       encoding: UTF-8
-      string: '{"id":"127412320959275","access_token":"CAAPZCgvhYKvsBAO2U65uD26R8cB3cMUzLC5gvE01ft8mZB2mFvtWH9mUZATSpiAwqDYO5VA251904QNTr8F4DHUGvqqfHpvtDGKZBom4nKHZC382UPuZC6xZAPy45YcbDZA6Y9uavRKF0RAsIiIDcdFP7QQQCJD2eFTSeuFFEv9vmEbaplEaZAcQqTfYNLhwcmlUZD","login_url":"https:\/\/developers.facebook.com\/checkpoint\/test-user-login\/127412320959275\/","email":"wzkpsqk_thurnstein_1449046924\u0040tfbnw.net","password":"317343020"}'
+      string: '{"id":"100300777009168","access_token":"CAAG76IA4ZAtABAENyUBjopcCOaQZALiNrnKzIGLrklrsB7TSCxFTZAYvZAqWFCJqZAY8ZBrVVP6eoIr6FZAZCMpKXjj7EzTFCHtTqQciKlkRL795MYReZBBdNvVlcMSlfhhsZCcZAMZAwr6svPGg5PinDLwCvcKEhhzcfYYFHMHlvsz0cIzhWDKOQYvaZBjmnZCLZB0EMIZD","login_url":"https:\/\/developers.facebook.com\/checkpoint\/test-user-login\/100300777009168\/","email":"ppquksu_wongwitz_1449270710\u0040tfbnw.net","password":"1783960566"}'
     http_version: 
-  recorded_at: Wed, 02 Dec 2015 09:02:20 GMT
+  recorded_at: Fri, 04 Dec 2015 23:11:55 GMT
 - request:
     method: post
     uri: https://graph.facebook.com/oauth/access_token
     body:
       encoding: UTF-8
-      string: client_id=1125362907491067&client_secret=57b63caabfe3d1a9b568e8660d3d7d65&fb_exchange_token=CAAPZCgvhYKvsBAO2U65uD26R8cB3cMUzLC5gvE01ft8mZB2mFvtWH9mUZATSpiAwqDYO5VA251904QNTr8F4DHUGvqqfHpvtDGKZBom4nKHZC382UPuZC6xZAPy45YcbDZA6Y9uavRKF0RAsIiIDcdFP7QQQCJD2eFTSeuFFEv9vmEbaplEaZAcQqTfYNLhwcmlUZD&grant_type=fb_exchange_token
+      string: client_id=488082234697424&client_secret=62162fa577e11cdd671dce539d9629ca&fb_exchange_token=CAAG76IA4ZAtABAENyUBjopcCOaQZALiNrnKzIGLrklrsB7TSCxFTZAYvZAqWFCJqZAY8ZBrVVP6eoIr6FZAZCMpKXjj7EzTFCHtTqQciKlkRL795MYReZBBdNvVlcMSlfhhsZCcZAMZAwr6svPGg5PinDLwCvcKEhhzcfYYFHMHlvsz0cIzhWDKOQYvaZBjmnZCLZB0EMIZD&grant_type=fb_exchange_token
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -123,9 +123,9 @@ http_interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       X-Fb-Trace-Id:
-      - FQpSFxnVO+n
+      - Abv1cKW53T9
       X-Fb-Rev:
-      - '2067909'
+      - '2073942'
       Pragma:
       - no-cache
       Cache-Control:
@@ -135,21 +135,21 @@ http_interactions:
       Expires:
       - Sat, 01 Jan 2000 00:00:00 GMT
       X-Fb-Debug:
-      - 70hZzR/HnjKZ576Uc0XDf/9vFfysMSAAbJgXZfzCfXqf8XdAlk6/Zo4fG5ItrhvNIGTO+W3QTnw3SOTHTUXtQw==
+      - E5dD1YeamIvshpXY41KlhhhX1+Ijnj0NGZw3eV6AL588SK3i7fpMe1pB7E8kqTaArIPy/ih18yGXWQ4uaC/peA==
       Date:
-      - Wed, 02 Dec 2015 09:02:10 GMT
+      - Fri, 04 Dec 2015 23:11:55 GMT
       Connection:
       - keep-alive
       Content-Length:
-      - '227'
+      - '228'
     body:
       encoding: UTF-8
-      string: access_token=CAAPZCgvhYKvsBAOsZAzImm2f8ZCuwD2sGCusQ0PtrMtuzelvbKEpBKCVIjjUhp8jhqKJQbsEdjBxpfnIOIZBjTHVxX6xWdvopnWftZAklq7n3QEvycSlSV2wZAActNp7mPMBM717qByH6nnmr6NutvZCdmLGA72UjQDTH5fN2X194t9OKdcQ6ZCgUKPvLjagwrsZD&expires=5184000
+      string: access_token=CAAG76IA4ZAtABADNUdpz6IuNgeWYVZBBzvTe7hpgWK4yCofJWRe3nUZCZAbAAS9k3uNrC8Jv0tscq9oOmYId4AauXk6sfCqqcYbJGWIIpZC7PcMrNfgEluc1hITadK5oEVKWq86CwmFm0qJOftEk6if4Gc5RXZAQUJcZAB0awSgZARWHZAYp3NoQ8B02eCzUo8CoZD&expires=5184000
     http_version: 
-  recorded_at: Wed, 02 Dec 2015 09:02:21 GMT
+  recorded_at: Fri, 04 Dec 2015 23:11:55 GMT
 - request:
     method: get
-    uri: https://graph.facebook.com/oauth/client_code?access_token=CAAPZCgvhYKvsBAOsZAzImm2f8ZCuwD2sGCusQ0PtrMtuzelvbKEpBKCVIjjUhp8jhqKJQbsEdjBxpfnIOIZBjTHVxX6xWdvopnWftZAklq7n3QEvycSlSV2wZAActNp7mPMBM717qByH6nnmr6NutvZCdmLGA72UjQDTH5fN2X194t9OKdcQ6ZCgUKPvLjagwrsZD&client_id=1125362907491067&client_secret=57b63caabfe3d1a9b568e8660d3d7d65&redirect_uri=http://localhost:3000/
+    uri: https://graph.facebook.com/oauth/client_code?access_token=CAAG76IA4ZAtABADNUdpz6IuNgeWYVZBBzvTe7hpgWK4yCofJWRe3nUZCZAbAAS9k3uNrC8Jv0tscq9oOmYId4AauXk6sfCqqcYbJGWIIpZC7PcMrNfgEluc1hITadK5oEVKWq86CwmFm0qJOftEk6if4Gc5RXZAQUJcZAB0awSgZARWHZAYp3NoQ8B02eCzUo8CoZD&client_id=488082234697424&client_secret=62162fa577e11cdd671dce539d9629ca&redirect_uri=http://localhost:3000/
     body:
       encoding: US-ASCII
       string: ''
@@ -170,9 +170,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Fb-Trace-Id:
-      - CgOzuWK93kA
+      - CLgzzh5NF0N
       X-Fb-Rev:
-      - '2067909'
+      - '2073942'
       Pragma:
       - no-cache
       Cache-Control:
@@ -182,21 +182,21 @@ http_interactions:
       Expires:
       - Sat, 01 Jan 2000 00:00:00 GMT
       X-Fb-Debug:
-      - o1ludGcrgJsGzTImWh0JLmw07YeawjOQ8eY+dllUoyi/JtnxMx8iW0cEM5utr9IPnmHgNNH393jRZ6qo9SJurg==
+      - JWVg497AUvH112mc3I+YjobH98PvtjeqMfn5fTvz3blRA3GPx03wVXlpTHlkmdIjcEgnTmm6KkNCm7zt3ylMOg==
       Date:
-      - Wed, 02 Dec 2015 09:02:10 GMT
+      - Fri, 04 Dec 2015 23:11:55 GMT
       Connection:
       - keep-alive
       Content-Length:
-      - '334'
+      - '377'
     body:
       encoding: UTF-8
-      string: '{"code":"AQAmV5XUuwyjNT04v8IuTroD3HmA5Nv9Xvlgp8MKMt4Nnoey8ay-OFFDkR2GRbUHSds0jkQEuoLUge_jL4aVV1aw6FbXCGhwYdvbik6rOEbxWKYA-YkNsWS2w4V0Z8xSZ29y5b4WzEqMImoqTjEMbv2mEhMv2BGMOljtYD1IfWFJAL5fU3Gh2pfZ5KGcuOflGuD5jQ-qng_C8lak2gJS9mWMMZlsR3ZioyKr3gF-GDioZmAHzFvpbjoZ_x79tsld3bmz4EB5JoUUgepysqpBeWl6OqhyZf3m1oLRv1fCi4HJTCNx7yGWBbww2JTtE8wRTJI"}'
+      string: '{"code":"AQB6log31_LGEnQemYKcVM1nuL6rlKHk8_htvMofhW5Ef47-WXUBfphkceiwREusLfRLkCB8-5EMMUGXp4S_w3tSpHUFJnwKiulnNfQmvKprKI24P6pDwCAICJPTMgqLnbdzewlYFbYIqCEFvbi_Yy_QHXdYcoQFND1F_s_SZ022czuUpcRqUbW4pLEer2Y_U_oHI9spG0oxpRaVtQbJcChcEL4NkAKVoNMcnWFoZjHmd2c70T4vr1yriHVkQUYx3ba6tt_dNPbDeOhmtvQA8TEEFjHqtOLHaMg0gpX2RoYXqy_bOAYUKFdOQoIaki3QwMn973bdCBn7q4sOw-JALu0HWXApPPfco_KDxV9tBB2ykA"}'
     http_version: 
-  recorded_at: Wed, 02 Dec 2015 09:02:21 GMT
+  recorded_at: Fri, 04 Dec 2015 23:11:55 GMT
 - request:
     method: get
-    uri: https://graph.facebook.com/oauth/access_token?client_id=1125362907491067&client_secret=57b63caabfe3d1a9b568e8660d3d7d65&code=AQAmV5XUuwyjNT04v8IuTroD3HmA5Nv9Xvlgp8MKMt4Nnoey8ay-OFFDkR2GRbUHSds0jkQEuoLUge_jL4aVV1aw6FbXCGhwYdvbik6rOEbxWKYA-YkNsWS2w4V0Z8xSZ29y5b4WzEqMImoqTjEMbv2mEhMv2BGMOljtYD1IfWFJAL5fU3Gh2pfZ5KGcuOflGuD5jQ-qng_C8lak2gJS9mWMMZlsR3ZioyKr3gF-GDioZmAHzFvpbjoZ_x79tsld3bmz4EB5JoUUgepysqpBeWl6OqhyZf3m1oLRv1fCi4HJTCNx7yGWBbww2JTtE8wRTJI&redirect_uri=http://localhost:3000/
+    uri: https://graph.facebook.com/oauth/access_token?client_id=488082234697424&client_secret=62162fa577e11cdd671dce539d9629ca&code=AQB6log31_LGEnQemYKcVM1nuL6rlKHk8_htvMofhW5Ef47-WXUBfphkceiwREusLfRLkCB8-5EMMUGXp4S_w3tSpHUFJnwKiulnNfQmvKprKI24P6pDwCAICJPTMgqLnbdzewlYFbYIqCEFvbi_Yy_QHXdYcoQFND1F_s_SZ022czuUpcRqUbW4pLEer2Y_U_oHI9spG0oxpRaVtQbJcChcEL4NkAKVoNMcnWFoZjHmd2c70T4vr1yriHVkQUYx3ba6tt_dNPbDeOhmtvQA8TEEFjHqtOLHaMg0gpX2RoYXqy_bOAYUKFdOQoIaki3QwMn973bdCBn7q4sOw-JALu0HWXApPPfco_KDxV9tBB2ykA&redirect_uri=http://localhost:3000/
     body:
       encoding: US-ASCII
       string: ''
@@ -217,9 +217,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Fb-Trace-Id:
-      - G+lGdjpISKb
+      - DeGKkWoF/N6
       X-Fb-Rev:
-      - '2067909'
+      - '2073942'
       Pragma:
       - no-cache
       Cache-Control:
@@ -229,21 +229,21 @@ http_interactions:
       Expires:
       - Sat, 01 Jan 2000 00:00:00 GMT
       X-Fb-Debug:
-      - p1447I6ABF+rghFj28xSh09CCf+p9Jss72opfBVrofcP7R1Szz/uw87MbrB4MJplejX8dzAsCg7pYau814syUA==
+      - l6k9CMWgA6nikKpmdF1iXcCc37PkfyGqKpvKw5JglIPefdzRoUivu6fEaginbEZoMD5OLux4U+L1879+LYB6yQ==
       Date:
-      - Wed, 02 Dec 2015 09:02:11 GMT
+      - Fri, 04 Dec 2015 23:11:55 GMT
       Connection:
       - keep-alive
       Content-Length:
-      - '266'
+      - '263'
     body:
       encoding: UTF-8
-      string: '{"access_token":"CAAPZCgvhYKvsBAEaw8DZC9mSK0oXqA8VKHCGt6cHlrJBwTNcAvInZBdJZAHU2KtOrdB0YLG1H7kfZBd4QC7vwMIrmaqs3SFjCnZAKGT6CegBJUHor9tHz7CzPVEbUk0yYNRdnKGWZBArrc3dZC76r97s7gUVPZBt6bgN1G7UnYD85hD5lfAK7e8aM","machine_id":"k7NeVnMWYq-r7m-pJNrMDkvj","expires_in":5183999}'
+      string: '{"access_token":"CAAG76IA4ZAtABAOJSOAfa3L9NJFZADuGo9x8ttE2iIKCjkIUo05R3ZBrBHDTyuPJJD2XtqGFMeFnXIXUVoYqvBTgqYvwNd5CxP7g5DysXafDSPQqWaZCbd8zRyyQefNn49KWVZB5Oc88Bj8b6sOWtPnKDxcIugpV4zMdKaoMVkZBB9TbSJCMh9","machine_id":"ux1iVjevV-4mmM6qjp3FAdT2","expires_in":5184000}'
     http_version: 
-  recorded_at: Wed, 02 Dec 2015 09:02:22 GMT
+  recorded_at: Fri, 04 Dec 2015 23:11:55 GMT
 - request:
     method: get
-    uri: https://graph.facebook.com/me?access_token=CAAPZCgvhYKvsBAEaw8DZC9mSK0oXqA8VKHCGt6cHlrJBwTNcAvInZBdJZAHU2KtOrdB0YLG1H7kfZBd4QC7vwMIrmaqs3SFjCnZAKGT6CegBJUHor9tHz7CzPVEbUk0yYNRdnKGWZBArrc3dZC76r97s7gUVPZBt6bgN1G7UnYD85hD5lfAK7e8aM&appsecret_proof=c579d52ed164867bd091c69b28953abf0eecb78f6a3fa50ce0617b97754e3526&fields=email,first_name,last_name
+    uri: https://graph.facebook.com/me?access_token=CAAG76IA4ZAtABAOJSOAfa3L9NJFZADuGo9x8ttE2iIKCjkIUo05R3ZBrBHDTyuPJJD2XtqGFMeFnXIXUVoYqvBTgqYvwNd5CxP7g5DysXafDSPQqWaZCbd8zRyyQefNn49KWVZB5Oc88Bj8b6sOWtPnKDxcIugpV4zMdKaoMVkZBB9TbSJCMh9&appsecret_proof=541bc6fdf39a9d84310e0505bd5edfb9d0a38312997016aeefd725639be322b2&fields=email,first_name,last_name
     body:
       encoding: US-ASCII
       string: ''
@@ -264,30 +264,30 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Fb-Trace-Id:
-      - G132rgtio/0
+      - DVDv0piIMia
       X-Fb-Rev:
-      - '2067909'
+      - '2073942'
       Etag:
-      - '"437bdd27b988a45b1e85338ae5c0b2a4c0e47458"'
+      - '"afc21540db88f8a910282c00d82779e95f11cca0"'
       Pragma:
       - no-cache
       Cache-Control:
       - private, no-cache, no-store, must-revalidate
       Facebook-Api-Version:
-      - v2.4
+      - v2.5
       Expires:
       - Sat, 01 Jan 2000 00:00:00 GMT
       X-Fb-Debug:
-      - 59RKkxS1NbxirGrLXHLGLbwnbBPf07IODJIDrB1eoe365TcNvs1iWze5y0WmdKER8UxXpy/kKtaXO3QP2xeHHQ==
+      - "+zvN9UfD1IjujgfTxeeZpNCxPHCrdCwfmYT8TG8/doXppD34niKus+Azj6/Hdf0EBMeMx3I3QL5CabbnM6xnXw=="
       Date:
-      - Wed, 02 Dec 2015 09:02:12 GMT
+      - Fri, 04 Dec 2015 23:11:56 GMT
       Connection:
       - keep-alive
       Content-Length:
-      - '127'
+      - '121'
     body:
       encoding: UTF-8
-      string: '{"email":"wzkpsqk_thurnstein_1449046924\u0040tfbnw.net","first_name":"Barbara","last_name":"Thurnstein","id":"127412320959275"}'
+      string: '{"email":"ppquksu_wongwitz_1449270710\u0040tfbnw.net","first_name":"Maria","last_name":"Wongwitz","id":"100300777009168"}'
     http_version: 
-  recorded_at: Wed, 02 Dec 2015 09:02:23 GMT
+  recorded_at: Fri, 04 Dec 2015 23:11:56 GMT
 recorded_with: VCR 3.0.0

--- a/spec/vcr/requests/api/tokens/facebook_user_not_found.yml
+++ b/spec/vcr/requests/api/tokens/facebook_user_not_found.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/me?access_token=non-existant-token&appsecret_proof=5e5d417feb25ea91af8c7ee07a1fce3f2fecf3f6711f1f33009aa5ee379fac31&fields=email,first_name,last_name
+    uri: https://graph.facebook.com/me?access_token=non-existant-token&appsecret_proof=5cf87f35920bd647d216415adffce7dc04ba652ed43a23a23e7b63fb496715ae&fields=email,first_name,last_name
     body:
       encoding: US-ASCII
       string: ''
@@ -25,9 +25,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Fb-Trace-Id:
-      - AWwW6NLjfH2
+      - A6PepT920Ec
       X-Fb-Rev:
-      - '2067909'
+      - '2073942'
       Pragma:
       - no-cache
       Cache-Control:
@@ -35,16 +35,16 @@ http_interactions:
       Expires:
       - Sat, 01 Jan 2000 00:00:00 GMT
       X-Fb-Debug:
-      - zUkHWK/gtxoq/eHWrX3E1Nq3MqXvVgJElP3WgD3tfnDKMOwlu8hjTLv6rQisG1+kFMoXH27IZWF1oPk5YZSQHA==
+      - c2CUl6sOqHTSvVAl8YUGGBu4MsWbDBa0+9mYbIJz58T7Tq5LdFjFznCVwdwDy06XMQST/VV/BscgLyWlQYzJgQ==
       Date:
-      - Wed, 02 Dec 2015 09:02:03 GMT
+      - Fri, 04 Dec 2015 23:11:49 GMT
       Connection:
       - keep-alive
       Content-Length:
       - '113'
     body:
       encoding: UTF-8
-      string: '{"error":{"message":"Invalid OAuth access token.","type":"OAuthException","code":190,"fbtrace_id":"AWwW6NLjfH2"}}'
+      string: '{"error":{"message":"Invalid OAuth access token.","type":"OAuthException","code":190,"fbtrace_id":"A6PepT920Ec"}}'
     http_version: 
-  recorded_at: Wed, 02 Dec 2015 09:02:14 GMT
+  recorded_at: Fri, 04 Dec 2015 23:11:49 GMT
 recorded_with: VCR 3.0.0

--- a/spec/vcr/requests/api/tokens/facebook_user_not_found.yml
+++ b/spec/vcr/requests/api/tokens/facebook_user_not_found.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://graph.facebook.com/me?access_token=non-existant-token&appsecret_proof=5e5d417feb25ea91af8c7ee07a1fce3f2fecf3f6711f1f33009aa5ee379fac31&fields=email,first_name,last_name
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Www-Authenticate:
+      - OAuth "Facebook Platform" "invalid_token" "Invalid OAuth access token."
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Fb-Trace-Id:
+      - AWwW6NLjfH2
+      X-Fb-Rev:
+      - '2067909'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-store
+      Expires:
+      - Sat, 01 Jan 2000 00:00:00 GMT
+      X-Fb-Debug:
+      - zUkHWK/gtxoq/eHWrX3E1Nq3MqXvVgJElP3WgD3tfnDKMOwlu8hjTLv6rQisG1+kFMoXH27IZWF1oPk5YZSQHA==
+      Date:
+      - Wed, 02 Dec 2015 09:02:03 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '113'
+    body:
+      encoding: UTF-8
+      string: '{"error":{"message":"Invalid OAuth access token.","type":"OAuthException","code":190,"fbtrace_id":"AWwW6NLjfH2"}}'
+    http_version: 
+  recorded_at: Wed, 02 Dec 2015 09:02:14 GMT
+recorded_with: VCR 3.0.0

--- a/spec/vcr/requests/api/users/valid_facebook_request.yml
+++ b/spec/vcr/requests/api/users/valid_facebook_request.yml
@@ -1,0 +1,244 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://graph.facebook.com/oauth/access_token
+    body:
+      encoding: UTF-8
+      string: client_id=1125362907491067&client_secret=57b63caabfe3d1a9b568e8660d3d7d65&grant_type=client_credentials
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/plain; charset=UTF-8
+      X-Fb-Trace-Id:
+      - EbRpWUXXXq4
+      X-Fb-Rev:
+      - '2067909'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Facebook-Api-Version:
+      - v2.0
+      Expires:
+      - Sat, 01 Jan 2000 00:00:00 GMT
+      X-Fb-Debug:
+      - 29s8Z+N39lvTRnwIZgiJktjnALpk/dQqJTeHDGwllZi51PoK8Z+bbL1AHdcFP78rNtH9KtM+t+KpIEFpwOzA+A==
+      Date:
+      - Wed, 02 Dec 2015 08:31:43 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '57'
+    body:
+      encoding: UTF-8
+      string: access_token=1125362907491067|BX4v-oq4_lmDeePcEA0q4XNeoVk
+    http_version: 
+  recorded_at: Wed, 02 Dec 2015 08:31:54 GMT
+- request:
+    method: post
+    uri: https://graph.facebook.com/1125362907491067/accounts/test-users
+    body:
+      encoding: UTF-8
+      string: access_token=1125362907491067%7CBX4v-oq4_lmDeePcEA0q4XNeoVk&installed=true&permissions=email%2Cuser_friends
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Fb-Trace-Id:
+      - Fxr11ENXumH
+      X-Fb-Rev:
+      - '2067909'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Facebook-Api-Version:
+      - v2.4
+      Expires:
+      - Sat, 01 Jan 2000 00:00:00 GMT
+      X-Fb-Debug:
+      - H3o7W2x7NNvcxGTCSgiLHx9QFfDYZRU97QUJdGzGVuJvd8zZvcQoxHJXec10H4so6LI5fqRi3eoieHaMPDc86w==
+      Date:
+      - Wed, 02 Dec 2015 08:31:48 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '414'
+    body:
+      encoding: UTF-8
+      string: '{"id":"122799728087988","access_token":"CAAPZCgvhYKvsBAFuC0XoCa8lMoFk3fAm0KUdmQqPJLMp0PX2WlnWSEkr9Mmds8X0jEZAyZA8ZBuAObF3A0Eg4dFZBGwgOPZB8eyfTVIZA8nibE34Ig1kIceMGD3iQDbPBhoGEgtEhXG4B3ZAPhMcm9ApWTnMqWfxB0G0uT93WbOqOyQIwAbDOfOtob8CMTBjtoMZD","login_url":"https:\/\/developers.facebook.com\/checkpoint\/test-user-login\/122799728087988\/","email":"acmpvim_romanberg_1449045104\u0040tfbnw.net","password":"1121681349"}'
+    http_version: 
+  recorded_at: Wed, 02 Dec 2015 08:31:59 GMT
+- request:
+    method: post
+    uri: https://graph.facebook.com/oauth/access_token
+    body:
+      encoding: UTF-8
+      string: client_id=1125362907491067&client_secret=57b63caabfe3d1a9b568e8660d3d7d65&fb_exchange_token=CAAPZCgvhYKvsBAFuC0XoCa8lMoFk3fAm0KUdmQqPJLMp0PX2WlnWSEkr9Mmds8X0jEZAyZA8ZBuAObF3A0Eg4dFZBGwgOPZB8eyfTVIZA8nibE34Ig1kIceMGD3iQDbPBhoGEgtEhXG4B3ZAPhMcm9ApWTnMqWfxB0G0uT93WbOqOyQIwAbDOfOtob8CMTBjtoMZD&grant_type=fb_exchange_token
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/plain; charset=UTF-8
+      X-Fb-Trace-Id:
+      - Fm6CVVIBvDN
+      X-Fb-Rev:
+      - '2067909'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Facebook-Api-Version:
+      - v2.0
+      Expires:
+      - Sat, 01 Jan 2000 00:00:00 GMT
+      X-Fb-Debug:
+      - CyIbO9uNMofL0Fuu5DknIaN3t+xM+yUp7NgBVK6lhWS/31wblB7umETQfjfFv3GP+17ICa0jxPnCBoPbxpOzog==
+      Date:
+      - Wed, 02 Dec 2015 08:31:49 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+    body:
+      encoding: UTF-8
+      string: access_token=CAAPZCgvhYKvsBAO50SZAQ5xw8kQlBL8cPErNUOYn0l9U8gzvJFJqV0uaBTUTmEtly64NBduVp0dO44lZCls2TmdZBsp80pv5hVSzvFuZAeZC8agZBAxaPwA87rStEZAlpZAm2yNWgd81DSnUAeE2MoHxvsEeUFxWaQBxjkNMZCjm5hlULh90vhNDhK&expires=5184000
+    http_version: 
+  recorded_at: Wed, 02 Dec 2015 08:32:00 GMT
+- request:
+    method: get
+    uri: https://graph.facebook.com/oauth/client_code?access_token=CAAPZCgvhYKvsBAO50SZAQ5xw8kQlBL8cPErNUOYn0l9U8gzvJFJqV0uaBTUTmEtly64NBduVp0dO44lZCls2TmdZBsp80pv5hVSzvFuZAeZC8agZBAxaPwA87rStEZAlpZAm2yNWgd81DSnUAeE2MoHxvsEeUFxWaQBxjkNMZCjm5hlULh90vhNDhK&client_id=1125362907491067&client_secret=57b63caabfe3d1a9b568e8660d3d7d65&redirect_uri=http://localhost:3000/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Fb-Trace-Id:
+      - F/XrM/Kg0h/
+      X-Fb-Rev:
+      - '2067909'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Facebook-Api-Version:
+      - v2.0
+      Expires:
+      - Sat, 01 Jan 2000 00:00:00 GMT
+      X-Fb-Debug:
+      - ZkwFiXiwzderkHCldQa65RxWPTVh2GjoZsPaCws5HDrZ/fuo699aFAR9oVy8mTYKNKONskTMM1V1464ZOkDUNQ==
+      Date:
+      - Wed, 02 Dec 2015 08:31:49 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '334'
+    body:
+      encoding: UTF-8
+      string: '{"code":"AQCiMRjgR-YH4R7DJLzQacHefLGf6eE192PscasG1PGPqh0mR0i19stCSLXwx1L8m9_gIss6kBAY1UqwNelyHOgn10n6pLYBhWKfleOzEJLUzZGtjWfF7Ry9BgyLsyhYlfrUy9rsRQ0xrM3o8FW7WgRRZDUIvt_kT7uW48feK1Jfj6rbNRSdYtby0WnPYOUkDG1j1BUZ7a362vYNW3eH2Yn70MvtAVkqiC5fH1X1pZh0JIoLMarb0j6F9qi7rOn4mYsI_hhpLAZYOLpqdJunAM2TxgjIthaF0dNngwV0Fg4qtBgrJMnYmGQMxartew0aIQ0"}'
+    http_version: 
+  recorded_at: Wed, 02 Dec 2015 08:32:00 GMT
+- request:
+    method: get
+    uri: https://graph.facebook.com/oauth/access_token?client_id=1125362907491067&client_secret=57b63caabfe3d1a9b568e8660d3d7d65&code=AQCiMRjgR-YH4R7DJLzQacHefLGf6eE192PscasG1PGPqh0mR0i19stCSLXwx1L8m9_gIss6kBAY1UqwNelyHOgn10n6pLYBhWKfleOzEJLUzZGtjWfF7Ry9BgyLsyhYlfrUy9rsRQ0xrM3o8FW7WgRRZDUIvt_kT7uW48feK1Jfj6rbNRSdYtby0WnPYOUkDG1j1BUZ7a362vYNW3eH2Yn70MvtAVkqiC5fH1X1pZh0JIoLMarb0j6F9qi7rOn4mYsI_hhpLAZYOLpqdJunAM2TxgjIthaF0dNngwV0Fg4qtBgrJMnYmGQMxartew0aIQ0&redirect_uri=http://localhost:3000/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Fb-Trace-Id:
+      - BmGyn1s02/I
+      X-Fb-Rev:
+      - '2067909'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Facebook-Api-Version:
+      - v2.0
+      Expires:
+      - Sat, 01 Jan 2000 00:00:00 GMT
+      X-Fb-Debug:
+      - Hs9ee54tkW+7bGhNalLfhaX/mS8DKGZdcN4GaV1h6KqA2fg3sSJtXw9vv4OXvhgKxtUDWc4YqFVmghnmz43W6A==
+      Date:
+      - Wed, 02 Dec 2015 08:31:50 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '270'
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"CAAPZCgvhYKvsBAPc7BkV5YII6yZCvZCQqmElKc8cGeyqVsr26g2AZALBF8FGI2ZBDUnZCNefObk2iZBZBpkH0dt0uGjwyi1yDjOfGfYZAzEQg4QkJrCb1PPiZA2Jwm2FUI8WqmqlW0YeffFP656Pfa9x4zcIg5USCd3CeaZCzSURfLuJAZAcTZAWbGDoD","machine_id":"dqxeViX7NE4V22J9vt4ILG3d","expires_in":5183999}'
+    http_version: 
+  recorded_at: Wed, 02 Dec 2015 08:32:01 GMT
+recorded_with: VCR 3.0.0

--- a/spec/vcr/requests/api/users/valid_facebook_request.yml
+++ b/spec/vcr/requests/api/users/valid_facebook_request.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://graph.facebook.com/oauth/access_token
     body:
       encoding: UTF-8
-      string: client_id=1125362907491067&client_secret=57b63caabfe3d1a9b568e8660d3d7d65&grant_type=client_credentials
+      string: client_id=488082234697424&client_secret=62162fa577e11cdd671dce539d9629ca&grant_type=client_credentials
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -25,9 +25,9 @@ http_interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       X-Fb-Trace-Id:
-      - EbRpWUXXXq4
+      - BF5FB+R2wg5
       X-Fb-Rev:
-      - '2067909'
+      - '2073942'
       Pragma:
       - no-cache
       Cache-Control:
@@ -37,24 +37,24 @@ http_interactions:
       Expires:
       - Sat, 01 Jan 2000 00:00:00 GMT
       X-Fb-Debug:
-      - 29s8Z+N39lvTRnwIZgiJktjnALpk/dQqJTeHDGwllZi51PoK8Z+bbL1AHdcFP78rNtH9KtM+t+KpIEFpwOzA+A==
+      - wV2L7GMMRQEUIX+O2dW821svpWt2pTGVOybG1s8Kp5SjJBOajUyrvc5+JH7JFNTNzJcRWuhvZKeclf+goHIxgQ==
       Date:
-      - Wed, 02 Dec 2015 08:31:43 GMT
+      - Fri, 04 Dec 2015 23:12:06 GMT
       Connection:
       - keep-alive
       Content-Length:
-      - '57'
+      - '56'
     body:
       encoding: UTF-8
-      string: access_token=1125362907491067|BX4v-oq4_lmDeePcEA0q4XNeoVk
+      string: access_token=488082234697424|3Ni5iU_mYlazCYz4FpvhnW03RZg
     http_version: 
-  recorded_at: Wed, 02 Dec 2015 08:31:54 GMT
+  recorded_at: Fri, 04 Dec 2015 23:12:06 GMT
 - request:
     method: post
-    uri: https://graph.facebook.com/1125362907491067/accounts/test-users
+    uri: https://graph.facebook.com/488082234697424/accounts/test-users
     body:
       encoding: UTF-8
-      string: access_token=1125362907491067%7CBX4v-oq4_lmDeePcEA0q4XNeoVk&installed=true&permissions=email%2Cuser_friends
+      string: access_token=488082234697424%7C3Ni5iU_mYlazCYz4FpvhnW03RZg&installed=true&permissions=email%2Cuser_friends
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -74,36 +74,36 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Fb-Trace-Id:
-      - Fxr11ENXumH
+      - G8SUivqy0YN
       X-Fb-Rev:
-      - '2067909'
+      - '2073942'
       Pragma:
       - no-cache
       Cache-Control:
       - private, no-cache, no-store, must-revalidate
       Facebook-Api-Version:
-      - v2.4
+      - v2.5
       Expires:
       - Sat, 01 Jan 2000 00:00:00 GMT
       X-Fb-Debug:
-      - H3o7W2x7NNvcxGTCSgiLHx9QFfDYZRU97QUJdGzGVuJvd8zZvcQoxHJXec10H4so6LI5fqRi3eoieHaMPDc86w==
+      - ZFesPZs3vds5ahayMuwdB4rQrI20tBWE3gVROis/jIkQ2cLCkRS7eWSyIGeQEcOXct5bhPS0OW57BWYM5Vk/AQ==
       Date:
-      - Wed, 02 Dec 2015 08:31:48 GMT
+      - Fri, 04 Dec 2015 23:12:11 GMT
       Connection:
       - keep-alive
       Content-Length:
-      - '414'
+      - '419'
     body:
       encoding: UTF-8
-      string: '{"id":"122799728087988","access_token":"CAAPZCgvhYKvsBAFuC0XoCa8lMoFk3fAm0KUdmQqPJLMp0PX2WlnWSEkr9Mmds8X0jEZAyZA8ZBuAObF3A0Eg4dFZBGwgOPZB8eyfTVIZA8nibE34Ig1kIceMGD3iQDbPBhoGEgtEhXG4B3ZAPhMcm9ApWTnMqWfxB0G0uT93WbOqOyQIwAbDOfOtob8CMTBjtoMZD","login_url":"https:\/\/developers.facebook.com\/checkpoint\/test-user-login\/122799728087988\/","email":"acmpvim_romanberg_1449045104\u0040tfbnw.net","password":"1121681349"}'
+      string: '{"id":"118431745192741","access_token":"CAAG76IA4ZAtABADVnkBrkcU1j5AiROnD0I0nwCXPyp42Y1OqZAIZCKptvS8g0BAZAe5l8clz0PQuJuvZBuUTmrenWUgliGoETinTnGzcHHGDLuuR40gr1aU3DpKQXZBHSswQNStJHhC0Rdrva1TJPkoCdNqtuGqBmKjqZCWZAfiZA2K00HqAurZCCvcFoEiNam2j8ZD","login_url":"https:\/\/developers.facebook.com\/checkpoint\/test-user-login\/118431745192741\/","email":"fnrtxmr_narayanansky_1449270726\u0040tfbnw.net","password":"1658749836"}'
     http_version: 
-  recorded_at: Wed, 02 Dec 2015 08:31:59 GMT
+  recorded_at: Fri, 04 Dec 2015 23:12:11 GMT
 - request:
     method: post
     uri: https://graph.facebook.com/oauth/access_token
     body:
       encoding: UTF-8
-      string: client_id=1125362907491067&client_secret=57b63caabfe3d1a9b568e8660d3d7d65&fb_exchange_token=CAAPZCgvhYKvsBAFuC0XoCa8lMoFk3fAm0KUdmQqPJLMp0PX2WlnWSEkr9Mmds8X0jEZAyZA8ZBuAObF3A0Eg4dFZBGwgOPZB8eyfTVIZA8nibE34Ig1kIceMGD3iQDbPBhoGEgtEhXG4B3ZAPhMcm9ApWTnMqWfxB0G0uT93WbOqOyQIwAbDOfOtob8CMTBjtoMZD&grant_type=fb_exchange_token
+      string: client_id=488082234697424&client_secret=62162fa577e11cdd671dce539d9629ca&fb_exchange_token=CAAG76IA4ZAtABADVnkBrkcU1j5AiROnD0I0nwCXPyp42Y1OqZAIZCKptvS8g0BAZAe5l8clz0PQuJuvZBuUTmrenWUgliGoETinTnGzcHHGDLuuR40gr1aU3DpKQXZBHSswQNStJHhC0Rdrva1TJPkoCdNqtuGqBmKjqZCWZAfiZA2K00HqAurZCCvcFoEiNam2j8ZD&grant_type=fb_exchange_token
     headers:
       User-Agent:
       - Faraday v0.9.2
@@ -123,9 +123,9 @@ http_interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       X-Fb-Trace-Id:
-      - Fm6CVVIBvDN
+      - DxNRYRy9j7p
       X-Fb-Rev:
-      - '2067909'
+      - '2073942'
       Pragma:
       - no-cache
       Cache-Control:
@@ -135,21 +135,21 @@ http_interactions:
       Expires:
       - Sat, 01 Jan 2000 00:00:00 GMT
       X-Fb-Debug:
-      - CyIbO9uNMofL0Fuu5DknIaN3t+xM+yUp7NgBVK6lhWS/31wblB7umETQfjfFv3GP+17ICa0jxPnCBoPbxpOzog==
+      - "+3nFvQ7TSlo5i5XJTurRbxXl2w6v6mQfu7NtD0xoqCDIGbIzaciOygVwbuO9vRmlJl+SMhFFKOhLwJb3QlYyrw=="
       Date:
-      - Wed, 02 Dec 2015 08:31:49 GMT
+      - Fri, 04 Dec 2015 23:12:11 GMT
       Connection:
       - keep-alive
       Content-Length:
-      - '216'
+      - '230'
     body:
       encoding: UTF-8
-      string: access_token=CAAPZCgvhYKvsBAO50SZAQ5xw8kQlBL8cPErNUOYn0l9U8gzvJFJqV0uaBTUTmEtly64NBduVp0dO44lZCls2TmdZBsp80pv5hVSzvFuZAeZC8agZBAxaPwA87rStEZAlpZAm2yNWgd81DSnUAeE2MoHxvsEeUFxWaQBxjkNMZCjm5hlULh90vhNDhK&expires=5184000
+      string: access_token=CAAG76IA4ZAtABAOhpZCHp82ZBIZCaWnnYnV7Mum46hBsCfBF0Om9bmSjjz0szCDFnrIlc7VBfCpIpZALXH5ZCStmBfq8zyLucAz9RKv930QiPZCoaENuZBArpZAnREeIxP2Xfq2XJBZBM1VKZCkdCzwfERvjjpOg8IkiD70MiIM1qwcvzjtA8jsI34viHG1JgMcMOkZD&expires=5184000
     http_version: 
-  recorded_at: Wed, 02 Dec 2015 08:32:00 GMT
+  recorded_at: Fri, 04 Dec 2015 23:12:11 GMT
 - request:
     method: get
-    uri: https://graph.facebook.com/oauth/client_code?access_token=CAAPZCgvhYKvsBAO50SZAQ5xw8kQlBL8cPErNUOYn0l9U8gzvJFJqV0uaBTUTmEtly64NBduVp0dO44lZCls2TmdZBsp80pv5hVSzvFuZAeZC8agZBAxaPwA87rStEZAlpZAm2yNWgd81DSnUAeE2MoHxvsEeUFxWaQBxjkNMZCjm5hlULh90vhNDhK&client_id=1125362907491067&client_secret=57b63caabfe3d1a9b568e8660d3d7d65&redirect_uri=http://localhost:3000/
+    uri: https://graph.facebook.com/oauth/client_code?access_token=CAAG76IA4ZAtABAOhpZCHp82ZBIZCaWnnYnV7Mum46hBsCfBF0Om9bmSjjz0szCDFnrIlc7VBfCpIpZALXH5ZCStmBfq8zyLucAz9RKv930QiPZCoaENuZBArpZAnREeIxP2Xfq2XJBZBM1VKZCkdCzwfERvjjpOg8IkiD70MiIM1qwcvzjtA8jsI34viHG1JgMcMOkZD&client_id=488082234697424&client_secret=62162fa577e11cdd671dce539d9629ca&redirect_uri=http://localhost:3000/
     body:
       encoding: US-ASCII
       string: ''
@@ -170,9 +170,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Fb-Trace-Id:
-      - F/XrM/Kg0h/
+      - H/26ruueIHn
       X-Fb-Rev:
-      - '2067909'
+      - '2073942'
       Pragma:
       - no-cache
       Cache-Control:
@@ -182,21 +182,21 @@ http_interactions:
       Expires:
       - Sat, 01 Jan 2000 00:00:00 GMT
       X-Fb-Debug:
-      - ZkwFiXiwzderkHCldQa65RxWPTVh2GjoZsPaCws5HDrZ/fuo699aFAR9oVy8mTYKNKONskTMM1V1464ZOkDUNQ==
+      - knbOzk3EP1Nifk6rExRiqUxL+qpUuD5bcHrtlYmeKI7P1M6ubjo4r5qhDWQsfsxGlKLxmfZn8kgxiUex6IQ03w==
       Date:
-      - Wed, 02 Dec 2015 08:31:49 GMT
+      - Fri, 04 Dec 2015 23:12:11 GMT
       Connection:
       - keep-alive
       Content-Length:
-      - '334'
+      - '377'
     body:
       encoding: UTF-8
-      string: '{"code":"AQCiMRjgR-YH4R7DJLzQacHefLGf6eE192PscasG1PGPqh0mR0i19stCSLXwx1L8m9_gIss6kBAY1UqwNelyHOgn10n6pLYBhWKfleOzEJLUzZGtjWfF7Ry9BgyLsyhYlfrUy9rsRQ0xrM3o8FW7WgRRZDUIvt_kT7uW48feK1Jfj6rbNRSdYtby0WnPYOUkDG1j1BUZ7a362vYNW3eH2Yn70MvtAVkqiC5fH1X1pZh0JIoLMarb0j6F9qi7rOn4mYsI_hhpLAZYOLpqdJunAM2TxgjIthaF0dNngwV0Fg4qtBgrJMnYmGQMxartew0aIQ0"}'
+      string: '{"code":"AQCtxjIMNAlDQvvF8bbdYDoj_omfkTh4GbaxtNvAsBkxzTG3FOHltOphNXWkQGddExvdM5h01b-U7cFjLRkjyqIkfOxMmsvqI-0qVJQ-FU63QljRrKTrVUUsel04T9SfxaySK18h26_Zk41KMvAgh5OjE3YmPRZm-hUFDRdh66Zx9dBO_P9KTJcRHUEb2Jv_OX9oziLaSugRLLc4mVuztROm5qtWMHPrSki4i6ixv0Ad6ZHVQJGIwzqs5bs-W8rSbx0QXbjvN4riCaAhZx-yVDT5Eh0YRGQZoNQWocL5K1C95S7ASzu9WlDtvqgFw226mjTYSuHHUUf0s3u5vpa03wuESY93wAR-PiHF-6eEcTVsKg"}'
     http_version: 
-  recorded_at: Wed, 02 Dec 2015 08:32:00 GMT
+  recorded_at: Fri, 04 Dec 2015 23:12:11 GMT
 - request:
     method: get
-    uri: https://graph.facebook.com/oauth/access_token?client_id=1125362907491067&client_secret=57b63caabfe3d1a9b568e8660d3d7d65&code=AQCiMRjgR-YH4R7DJLzQacHefLGf6eE192PscasG1PGPqh0mR0i19stCSLXwx1L8m9_gIss6kBAY1UqwNelyHOgn10n6pLYBhWKfleOzEJLUzZGtjWfF7Ry9BgyLsyhYlfrUy9rsRQ0xrM3o8FW7WgRRZDUIvt_kT7uW48feK1Jfj6rbNRSdYtby0WnPYOUkDG1j1BUZ7a362vYNW3eH2Yn70MvtAVkqiC5fH1X1pZh0JIoLMarb0j6F9qi7rOn4mYsI_hhpLAZYOLpqdJunAM2TxgjIthaF0dNngwV0Fg4qtBgrJMnYmGQMxartew0aIQ0&redirect_uri=http://localhost:3000/
+    uri: https://graph.facebook.com/oauth/access_token?client_id=488082234697424&client_secret=62162fa577e11cdd671dce539d9629ca&code=AQCtxjIMNAlDQvvF8bbdYDoj_omfkTh4GbaxtNvAsBkxzTG3FOHltOphNXWkQGddExvdM5h01b-U7cFjLRkjyqIkfOxMmsvqI-0qVJQ-FU63QljRrKTrVUUsel04T9SfxaySK18h26_Zk41KMvAgh5OjE3YmPRZm-hUFDRdh66Zx9dBO_P9KTJcRHUEb2Jv_OX9oziLaSugRLLc4mVuztROm5qtWMHPrSki4i6ixv0Ad6ZHVQJGIwzqs5bs-W8rSbx0QXbjvN4riCaAhZx-yVDT5Eh0YRGQZoNQWocL5K1C95S7ASzu9WlDtvqgFw226mjTYSuHHUUf0s3u5vpa03wuESY93wAR-PiHF-6eEcTVsKg&redirect_uri=http://localhost:3000/
     body:
       encoding: US-ASCII
       string: ''
@@ -217,9 +217,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Fb-Trace-Id:
-      - BmGyn1s02/I
+      - HgkC8QnfuKK
       X-Fb-Rev:
-      - '2067909'
+      - '2073942'
       Pragma:
       - no-cache
       Cache-Control:
@@ -229,16 +229,16 @@ http_interactions:
       Expires:
       - Sat, 01 Jan 2000 00:00:00 GMT
       X-Fb-Debug:
-      - Hs9ee54tkW+7bGhNalLfhaX/mS8DKGZdcN4GaV1h6KqA2fg3sSJtXw9vv4OXvhgKxtUDWc4YqFVmghnmz43W6A==
+      - rAykxsEK7ovD+nUlFRZfEBbdcFEofqAGzHdV5GBdQlIeTP6u4x4abOkoBbe+acrNlh6XADdcH6wsL9bBvofzRA==
       Date:
-      - Wed, 02 Dec 2015 08:31:50 GMT
+      - Fri, 04 Dec 2015 23:12:12 GMT
       Connection:
       - keep-alive
       Content-Length:
-      - '270'
+      - '282'
     body:
       encoding: UTF-8
-      string: '{"access_token":"CAAPZCgvhYKvsBAPc7BkV5YII6yZCvZCQqmElKc8cGeyqVsr26g2AZALBF8FGI2ZBDUnZCNefObk2iZBZBpkH0dt0uGjwyi1yDjOfGfYZAzEQg4QkJrCb1PPiZA2Jwm2FUI8WqmqlW0YeffFP656Pfa9x4zcIg5USCd3CeaZCzSURfLuJAZAcTZAWbGDoD","machine_id":"dqxeViX7NE4V22J9vt4ILG3d","expires_in":5183999}'
+      string: '{"access_token":"CAAG76IA4ZAtABALdlIe2NmZBmtYmGFMNwNUZC6lii0unnHTCSWSdup2EOWFfK3VnZBKVnY0TeQ8OlG61VfCcZB49QgTeWT1SDyJXpkpaC3ZCWNMFPoHRrAnTZB8SLx5ZADGIQh0R7g2TXoZC9VdSpdhfHRGxNKkGELsXbG2MF5SNJRZCBM9MRiXZCsJnuOhZAXYRgTAZD","machine_id":"zB1iVmLO0ehwE766zMnT54Z-","expires_in":5183999}'
     http_version: 
-  recorded_at: Wed, 02 Dec 2015 08:32:01 GMT
+  recorded_at: Fri, 04 Dec 2015 23:12:12 GMT
 recorded_with: VCR 3.0.0


### PR DESCRIPTION
Closes #2 
# Implementation

I've used most of the code from ground-game/fieldthebern. Among other things, I had to add support for serialization of several new errors which weren't yet being serialized in this project.

Outside of this, there is nothing else happening here.

When creating a user, we do the same as creating a regular user, except `facebook_id` and `facebook_access_token` are permitted parameters now, meaning we store them as User fields as well.

When logging in through Facebook, we take the `facebook_access_token`, use it to get the `facebook_id`, then use that to find the user in the database.  

In both cases, **nothing else is happening yet**. In this flow, the client is the one that fill in user details from Facebook upon user creation, so that part isn't handled by the API. We don't have user photos or social features yet either, so that part doesn't need to be processed.
## New RSpec matcher

I also added a new RSpec matcher which allows us to simply check if the proper serializer is being used to create the json response for our request. This saves us from having to check each individual field, for which there should be no need, since we're already testing each serializer individually.

We can use this matcher to significantly reduce the amount of code in our request specs.
