### PR TITLE
Exposed GET /skill_categories endpoint

### DIFF
--- a/app/controllers/skill_categories_controller.rb
+++ b/app/controllers/skill_categories_controller.rb
@@ -1,0 +1,7 @@
+class SkillCategoriesController < ApplicationController
+
+  def index
+    authorize SkillCategory
+    render json: SkillCategory.all.includes(:skills)
+  end
+end

--- a/app/policies/skill_category_policy.rb
+++ b/app/policies/skill_category_policy.rb
@@ -1,0 +1,10 @@
+class SkillCategoryPolicy
+  def initialize (user, skill_category)
+    @user = user
+    @skill_category = skill_category
+  end
+
+  def index?
+    true
+  end
+end

--- a/app/serializers/skill_category_serializer.rb
+++ b/app/serializers/skill_category_serializer.rb
@@ -1,3 +1,5 @@
 class SkillCategorySerializer < ActiveModel::Serializer
   attributes :id, :title
+
+  has_many :skills
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,5 +25,6 @@ Rails.application.routes.draw do
     resources :post_likes, only: [:create, :destroy]
     resources :user_skills, only: [:create, :destroy]
     resources :projects, only: [:show, :index, :create, :update]
+    resources :skill_categories, only: [:index]
   end
 end

--- a/spec/requests/api/skill_categories_spec.rb
+++ b/spec/requests/api/skill_categories_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe "SkillCategories API" do
+
+  context "GET /skill_categories" do
+    before do
+      @skill_categories = create_list(:skill_category, 10)
+    end
+
+    context "when successful" do
+      before do
+        get "#{host}/skill_categories"
+      end
+
+      it "responds with a 200" do
+        expect(last_response.status).to eq 200
+      end
+
+      it "returns a list of skill categories, serialized using SkillCategorySerializer, with skill includes" do
+        expect(json).to serialize_collection(@skill_categories)
+                          .with(SkillCategorySerializer)
+                          .with_includes("skills")
+      end
+    end
+
+  end
+end

--- a/spec/serializers/skill_category_serializer_spec.rb
+++ b/spec/serializers/skill_category_serializer_spec.rb
@@ -3,7 +3,11 @@ require "rails_helper"
 describe SkillCategorySerializer, :type => :serializer do
 
   context "individual resource representation" do
-    let(:resource) { create(:skill_category) }
+    let(:resource) {
+      skill_category = create(:skill_category)
+      create_list(:skill, 10, skill_category: skill_category)
+      skill_category
+    }
 
     let(:serializer) { SkillCategorySerializer.new(resource) }
     let(:serialization) { ActiveModel::Serializer::Adapter.create(serializer) }
@@ -17,8 +21,8 @@ describe SkillCategorySerializer, :type => :serializer do
         expect(subject["attributes"]).not_to be_nil
       end
 
-      it "does not have a relationships object" do
-        expect(subject["relationships"]).to be_nil
+      it "has a relationships object" do
+        expect(subject["relationships"]).not_to be_nil
       end
 
       it "has an id" do
@@ -41,13 +45,39 @@ describe SkillCategorySerializer, :type => :serializer do
       end
     end
 
-    context "included" do
+    context "relationships" do
       subject do
-        JSON.parse(serialization.to_json)["included"]
+        JSON.parse(serialization.to_json)["data"]["relationships"]
       end
 
-      it "should be empty" do
-        expect(subject).to be_nil
+      it "has a skills relationship" do
+        expect(subject["skills"]).not_to be_nil
+        expect(subject["skills"]["data"].length).to eq 10
+      end
+    end
+
+    context "included" do
+      context "when not including anything" do
+        subject do
+          JSON.parse(serialization.to_json)["included"]
+        end
+
+        it "should be empty" do
+          expect(subject).to be_nil
+        end
+      end
+
+      context "when including skills" do
+        let(:serialization) { ActiveModel::Serializer::Adapter.create(serializer, include: ["skills"]) }
+
+        subject do
+          JSON.parse(serialization.to_json)["included"]
+        end
+
+        it "should contain the skill category's skills" do
+          expect(subject).not_to be_nil
+          expect(subject.select{ |i| i["type"] == "skills"}.length).to eq 10
+        end
       end
     end
   end

--- a/spec/support/matchers/serializer_matcher.rb
+++ b/spec/support/matchers/serializer_matcher.rb
@@ -1,0 +1,41 @@
+RSpec::Matchers.define :serialize_object do |object|
+  match do |json|
+    serializer =  @serializer_klass.new(object)
+    serialization = ActiveModel::Serializer::Adapter.create(serializer) unless includes_specified?
+    serialization = ActiveModel::Serializer::Adapter.create(serializer, include: @includes) if includes_specified?
+    JSON.parse(serialization.to_json) == json
+  end
+
+  chain :with do |serializer_klass|
+    @serializer_klass = serializer_klass
+  end
+
+  chain :with_includes do |includes|
+    @includes = Array.wrap(includes)
+  end
+
+  def includes_specified?
+    @includes.present?
+  end
+end
+
+RSpec::Matchers.define :serialize_collection do |collection|
+  match do |json|
+    serializer =  ActiveModel::Serializer::CollectionSerializer.new collection, each_serializer: @serializer_klass
+    serialization = ActiveModel::Serializer::Adapter.create(serializer) unless includes_specified?
+    serialization = ActiveModel::Serializer::Adapter.create(serializer, include: @includes) if includes_specified?
+    JSON.parse(serialization.to_json) == json
+  end
+
+  chain :with do |serializer_klass|
+    @serializer_klass = serializer_klass
+  end
+
+  chain :with_includes do |includes|
+    @includes = Array.wrap(includes)
+  end
+
+  def includes_specified?
+    @includes.present?
+  end
+end


### PR DESCRIPTION
Closes #64 
# Implementation
- It's a public endpoint, accessible by anyone
- It returns a list of skill categories, each containing a title and a list of skills belonging to it
- It includes the skill rercords in the response

I'm using the new serialization helper to make sure everything is properly serialized. I also slightly expanded it for the purpose of this. We know have two possible helpers we can use

``` Ruby

expect(json).to serialize_object(@our_model_instance).with(OurSerializerClass).with_includes("inc")
expect(json).to serialize_collection(@our_list_of_model_instances).with(OurSerializerClass).with_includes("inc")
```
