### PR TITLE
Add sequencing to posts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,8 @@ gem 'koala'
 
 gem 'redcarpet'
 
+gem 'sequenced'
+
 group :development, :test do
   gem 'dotenv-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,6 +209,9 @@ GEM
     seed-fu (2.3.5)
       activerecord (>= 3.1, < 4.3)
       activesupport (>= 3.1, < 4.3)
+    sequenced (3.0.0)
+      activerecord (>= 3.0)
+      activesupport (>= 3.0)
     shoulda-matchers (3.0.1)
       activesupport (>= 4.0.0)
     sidekiq (4.0.1)
@@ -264,6 +267,7 @@ DEPENDENCIES
   rspec-rails (~> 3.0)
   rspec-sidekiq
   seed-fu
+  sequenced
   shoulda-matchers
   sidekiq
   spring

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,8 +1,11 @@
 class Post < ActiveRecord::Base
   belongs_to :user
   belongs_to :project
+
   has_many :comments
   has_many :post_likes
+
+  acts_as_sequenced scope: :project_id, column: :number
 
   validates_presence_of :project
   validates_presence_of :user

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -1,5 +1,6 @@
 class PostSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :status, :post_type, :likes_count, :markdown
+  attributes :id, :title, :body, :status, :post_type, :likes_count, :markdown,
+    :number
 
   has_many :comments
   belongs_to :user

--- a/db/migrate/20151204234343_add_number_to_posts.rb
+++ b/db/migrate/20151204234343_add_number_to_posts.rb
@@ -1,0 +1,7 @@
+class AddNumberToPosts < ActiveRecord::Migration
+  def change
+    add_column :posts, :number, :integer, null: false
+
+    add_index :posts, [:number, :project_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151203181837) do
+ActiveRecord::Schema.define(version: 20151204234343) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -110,7 +110,10 @@ ActiveRecord::Schema.define(version: 20151203181837) do
     t.datetime "updated_at",                        null: false
     t.integer  "post_likes_count", default: 0
     t.text     "markdown",                          null: false
+    t.integer  "number",                            null: false
   end
+
+  add_index "posts", ["number", "project_id"], name: "index_posts_on_number_and_project_id", unique: true, using: :btree
 
   create_table "projects", force: :cascade do |t|
     t.string   "title",             null: false

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -61,4 +61,21 @@ describe Post, :type => :model do
       expect(post.body).to eq "<h1>Hello World</h1>\n\n<p>Hello, world.</p>\n"
     end
   end
+
+  describe "sequencing" do
+    it "numbers posts for each project" do
+      project = create(:project)
+      first_post = create(:post, project: project)
+      second_post = create(:post, project: project)
+
+      expect(first_post.number).to eq 1
+      expect(second_post.number).to eq 2
+    end
+
+    it "should not allow a duplicate number to be set for the same project" do
+      project = create(:project)
+      first_post = create(:post, project: project)
+      expect { create(:post, project: project, number: 1) }.to raise_error ActiveRecord::RecordNotUnique
+    end
+  end
 end

--- a/spec/requests/api/posts_spec.rb
+++ b/spec/requests/api/posts_spec.rb
@@ -113,6 +113,18 @@ describe "Posts API" do
         expect(json).to contain_an_error_of_type("VALIDATION_ERROR").with_message("Title can't be blank")
       end
 
+      it "does not accept a 'number' to be set directly" do
+        params = { data: { type: "posts",
+          attributes: { title: "Post title", markdown: "Post body", number: 3 },
+          relationships: { project: { data: { id: 2 } } }
+        } }
+        authenticated_post "/posts", params, @token
+
+        expect(last_response.status).to eq 200
+        
+        expect(json.data.attributes.number).to eq 1
+      end
+
       it "does not require a 'post_type' to be specified" do
         params = { data: { type: "posts",
           attributes: { title: "Post title", markdown: "Post body" },

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -63,6 +63,10 @@ describe PostSerializer, :type => :serializer do
       it "has a 'likes_count'" do
         expect(subject["likes_count"]).to eql resource.likes_count
       end
+
+      it "has a 'number'" do
+        expect(subject["number"]).to eql resource.number
+      end
     end
 
     context "relationships" do


### PR DESCRIPTION
Closes #86 

This uses the `sequenced` gem to create a sequence of posts so we can use their numbering to make posts look a little nicer, and make their referencing a little easier.
