### PR TITLE
Add state and allow skipping numbers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ gem 'obscenity'
 
 gem 'sequenced'
 
+gem 'aasm'
+
 group :development, :test do
   gem 'dotenv-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    aasm (4.5.1)
     actionmailer (4.2.5)
       actionpack (= 4.2.5)
       actionview (= 4.2.5)
@@ -246,6 +247,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aasm
   active_model_serializers!
   aws-sdk
   bullet

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
 
-  before_action :doorkeeper_authorize!, only: [:create]
+  before_action :doorkeeper_authorize!, only: [:create, :update]
 
   def index
     authorize Post
@@ -25,7 +25,26 @@ class PostsController < ApplicationController
     end
   end
 
+  def update
+    post = Post.find(params[:id])
+    authorize post
+
+    post.assign_attributes(update_params)
+
+    if post.valid?
+      post.edit
+      post.save!
+      render json: post
+    else
+      render_validation_errors post.errors
+    end
+  end
+
   private
+
+    def update_params
+      record_attributes.permit(:markdown, :title)
+    end
 
     def create_params
       record_attributes.permit(:markdown, :title, :post_type).merge(relationships)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -41,11 +41,11 @@ class PostsController < ApplicationController
   private
 
     def update_params
-      record_attributes.permit(:markdown, :title)
+      record_attributes.permit(:markdown, :title, :state)
     end
 
     def create_params
-      record_attributes.permit(:markdown, :title, :post_type).merge(relationships)
+      record_attributes.permit(:markdown, :title, :state, :post_type).merge(relationships)
     end
 
     def project_relationship_id

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -31,9 +31,7 @@ class PostsController < ApplicationController
 
     post.assign_attributes(update_params)
 
-    if post.valid?
-      post.edit
-      post.save!
+    if post.update!
       render json: post
     else
       render_validation_errors post.errors

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -58,8 +58,20 @@ class Post < ActiveRecord::Base
     self.post_likes_count
   end
 
+  def update!
+    if aasm_state_was == "published" && self.changed?
+      self.edit!
+    else
+      self.save
+    end
+  end
+
   def state
     aasm_state
+  end
+
+  def state=(value)
+    self.publish if value == "published"
   end
 
   def edited_at

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -40,14 +40,29 @@ class Post < ActiveRecord::Base
   aasm do
     state :draft, initial: true
     state :published
+    state :edited
 
     event :publish do
       transitions from: :draft, to: :published
     end
+
+    event :edit do
+      transitions from: :published, to: :edited
+    end
   end
+
+  scope :active, -> { published.merge edited }
 
   def likes_count
     self.post_likes_count
+  end
+
+  def state
+    aasm_state
+  end
+
+  def edited_at
+    updated_at if edited?
   end
 
   private

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -71,7 +71,7 @@ class Post < ActiveRecord::Base
   end
 
   def state=(value)
-    self.publish if value == "published"
+    self.publish if value == "published" && self.draft?
   end
 
   def edited_at

--- a/app/policies/post_policy.rb
+++ b/app/policies/post_policy.rb
@@ -17,4 +17,8 @@ class PostPolicy
   def create?
     user.present?
   end
+
+  def update?
+    true # will be overriden in other PR
+  end
 end

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -1,6 +1,6 @@
 class PostSerializer < ActiveModel::Serializer
   attributes :id, :title, :body, :status, :post_type, :likes_count, :markdown,
-    :number
+    :number, :state
 
   has_many :comments
   has_many :post_user_mentions

--- a/db/migrate/20151209065037_add_state_to_posts.rb
+++ b/db/migrate/20151209065037_add_state_to_posts.rb
@@ -1,0 +1,5 @@
+class AddStateToPosts < ActiveRecord::Migration
+  def change
+    add_column :posts, :aasm_state, :string
+  end
+end

--- a/db/migrate/20151209065652_allow_skipping_number_on_posts.rb
+++ b/db/migrate/20151209065652_allow_skipping_number_on_posts.rb
@@ -1,0 +1,11 @@
+class AllowSkippingNumberOnPosts < ActiveRecord::Migration
+  def up
+    change_column :posts, :number, :integer, null: true
+    remove_index :posts, [:number, :project_id]
+  end
+
+  def down
+    change_column :posts, :number, :integer, null: false
+    add_index :posts, [:number, :project_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151208115704) do
+ActiveRecord::Schema.define(version: 20151209065652) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "comment_user_mentions", force: :cascade do |t|
+    t.integer  "user_id",     null: false
+    t.integer  "comment_id",  null: false
+    t.integer  "post_id",     null: false
+    t.string   "username",    null: false
+    t.integer  "start_index", null: false
+    t.integer  "end_index",   null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
 
   create_table "comments", force: :cascade do |t|
     t.text     "body",       null: false
@@ -43,6 +54,18 @@ ActiveRecord::Schema.define(version: 20151208115704) do
 
   add_index "members", ["model_id", "model_type"], name: "index_members_on_model_id_and_model_type", unique: true, using: :btree
   add_index "members", ["slug"], name: "index_members_on_slug", unique: true, using: :btree
+
+  create_table "notifications", force: :cascade do |t|
+    t.integer  "notifiable_id",   null: false
+    t.string   "notifiable_type", null: false
+    t.integer  "user_id",         null: false
+    t.string   "aasm_state"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
+
+  add_index "notifications", ["user_id", "notifiable_id", "notifiable_type"], name: "index_notifications_on_user_id_and_notifiable", unique: true, using: :btree
+  add_index "notifications", ["user_id"], name: "index_notifications_on_user_id", using: :btree
 
   create_table "oauth_access_grants", force: :cascade do |t|
     t.integer  "resource_owner_id", null: false
@@ -131,10 +154,9 @@ ActiveRecord::Schema.define(version: 20151208115704) do
     t.datetime "updated_at",                        null: false
     t.integer  "post_likes_count", default: 0
     t.text     "markdown",                          null: false
-    t.integer  "number",                            null: false
+    t.integer  "number"
+    t.string   "aasm_state"
   end
-
-  add_index "posts", ["number", "project_id"], name: "index_posts_on_number_and_project_id", unique: true, using: :btree
 
   create_table "projects", force: :cascade do |t|
     t.string   "title",              null: false

--- a/spec/factories/post_factory.rb
+++ b/spec/factories/post_factory.rb
@@ -6,6 +6,12 @@ FactoryGirl.define do
 
     association :user
     association :project
+
+    trait :published do
+      after :create do |post, evaluator|
+        post.publish!
+      end
+    end
   end
 
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -114,6 +114,56 @@ describe Post, :type => :model do
     end
   end
 
+  describe "#update!" do
+    context "when aasm_state_was 'published'" do
+      context "when the model has changed" do
+        it "should be edited" do
+          post = create(:post)
+          post.publish!
+
+          post.markdown = "New markdown"
+          post.update!
+
+          expect(post).to be_edited
+        end
+      end
+
+      context "when the model has not changed" do
+        it "should still be published" do
+          post = create(:post)
+          post.publish!
+
+          post.update!
+
+          expect(post).to be_published
+        end
+      end
+    end
+
+    context "when in draft state" do
+      it "should still be draft but saved" do
+        post = create(:post)
+        old_updated_at = post.updated_at
+        post.markdown = "New text"
+        post.update!
+
+        expect(post).to be_draft
+        expect(post.updated_at).not_to eq old_updated_at
+      end
+    end
+  end
+
+  describe "publishing" do
+    let(:post) { create(:post) }
+
+    it "publishes when state is set to 'published'" do
+      post.state = "published"
+      post.save
+
+      expect(post).to be_published
+    end
+  end
+
   describe "post user mentions" do
     context "when saving a post" do
       it "creates mentions only for existing users" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,7 +8,8 @@ require 'rspec/rails'
 require 'sidekiq/testing'
 require 'clearance/rspec'
 require 'paperclip/matchers'
-require "pundit/rspec"
+require 'pundit/rspec'
+require 'aasm/rspec'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/requests/api/posts_spec.rb
+++ b/spec/requests/api/posts_spec.rb
@@ -95,7 +95,7 @@ describe "Posts API" do
       before do
         @project = create(:project, owner: create(:organization))
         create(:user, username: "joshsmith")
-        @post = create(:post, project: @project, markdown: "Mentioning @joshsmith")
+        @post = create(:post, :published, project: @project, markdown: "Mentioning @joshsmith")
         create_list(:comment, 5, post: @post)
         get "#{host}/projects/#{@project.id}/posts/#{@post.number}"
       end
@@ -157,7 +157,7 @@ describe "Posts API" do
 
         expect(last_response.status).to eq 200
 
-        expect(json.data.attributes.number).to eq 1
+        expect(json.data.attributes.number).to eq nil
       end
 
       it "does not require a 'post_type' to be specified" do

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -69,6 +69,10 @@ describe PostSerializer, :type => :serializer do
       it "has a 'number'" do
         expect(subject["number"]).to eql resource.number
       end
+
+      it "has a 'state'" do
+        expect(subject["state"]).to eql resource.state
+      end
     end
 
     context "relationships" do


### PR DESCRIPTION
This will close #96, #98 and #104.

Instead of refactoring out `sequenced`, I opted to keep it and instead use the `skip lambda`, which requires doing some things with the indexes (unfortunate but necessary) and adding a new validation. This should ideally prevent collisions. I think postgres' locking will also prevent it, which is implemented in the gem.

Also adds a `published` and `draft` state.

We should still:
- [x] Fix couple of tests I lazily left failing
- [x] Add an `edited` bool, or make it a state if we can scope published posts to both published/edited
- [x] Add an `edited_at` timestamp whenever an `edited` post is saved
- [x] Create `PATCH` method to update the published/edited states
- [x] Write serializer specs to ensure the state is getting passed on. This shouldn't be named `aasm_state`, but wrapped somewhere (model?) to not be exposed directly
- [x] Write API-level specs to ensure we're setting this information correctly

And anything else I'm missing here.
