### PR TITLE
Added contributors and contributors_count to GET /projects/ endpoints

### DIFF
--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -14,7 +14,7 @@ class ContributorsController < ApplicationController
 
     if contributor.valid?
       contributor.save!
-      render json: contributor, include: [:user, :project]
+      render json: contributor
     else
       render_validation_errors contributor.errors
     end
@@ -29,7 +29,7 @@ class ContributorsController < ApplicationController
 
     if contributor.valid?
       contributor.save!
-      render json: contributor, include: [:user, :project]
+      render json: contributor
     else
       render_validation_errors contributor.errors
     end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -5,7 +5,7 @@ class ProjectsController < ApplicationController
   def index
     authorize Project
 
-    render json: Project.all
+    render json: Project.includes(:contributors).all
   end
 
   def show
@@ -85,7 +85,7 @@ class ProjectsController < ApplicationController
 
     def find_project_with_member!
       member = find_member!
-      Project.find_by!(slug: project_slug, owner: member.model)
+      Project.includes(:contributors).find_by!(slug: project_slug, owner: member.model)
     end
 
     def find_member!

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -1,5 +1,7 @@
 class ProjectSerializer < ActiveModel::Serializer
-  attributes :id, :title, :description, :icon_thumb_url, :icon_large_url
+  attributes :id, :title, :description, :icon_thumb_url, :icon_large_url, :contributors_count
+
+  has_many :contributors
 
   def icon_thumb_url
     object.icon.url(:thumb)

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -5,12 +5,27 @@ FactoryGirl.define do
 
     association :owner, factory: :organization
 
+    transient do
+      contributors_count 5
+      contributors_status "collaborator"
+    end
+
     trait :with_s3_icon do
       after(:build) do |project, evaluator|
         project.icon_file_name = 'project.jpg'
         project.icon_content_type = 'image/jpeg'
         project.icon_file_size = 1024
         project.icon_updated_at = Time.now
+      end
+    end
+
+
+    trait :with_contributors do
+
+      after(:create) do |project, evaluator|
+        evaluator.contributors_count.times do
+          create(:contributor, status: evaluator.contributors_status, project: project)
+        end
       end
     end
   end

--- a/spec/requests/api/contributors_spec.rb
+++ b/spec/requests/api/contributors_spec.rb
@@ -61,7 +61,7 @@ describe "Contributors API" do
           type: "contributors"
         } }, @token
 
-        # expect(last_response.status).to eq 422
+        expect(last_response.status).to eq 422
         expect(json).to be_a_valid_json_api_error
         expect(json).to contain_an_error_of_type("VALIDATION_ERROR").with_message("Project can't be blank")
       end
@@ -79,7 +79,7 @@ describe "Contributors API" do
             }
           } }, @token
 
-          # expect(last_response.status).to eq 422
+          expect(last_response.status).to eq 422
           expect(json).to be_a_valid_json_api_error
           expect(json).to contain_an_error_of_type("VALIDATION_ERROR").with_message("User has already been taken")
         end
@@ -97,38 +97,23 @@ describe "Contributors API" do
         end
 
         it "responds with a 200" do
-          # expect(last_response.status).to eq 200
+          expect(last_response.status).to eq 200
         end
 
         it "returns the created contributor" do
-          expect(json.data.attributes).not_to be_nil
-          expect(json.data.type).to eq "contributors"
+          expect(json).to serialize_object(Contributor.last).with(ContributorSerializer)
         end
 
         it "sets contributor user to current user" do
-          contributor_user = json.data.relationships.user
-          expect(contributor_user).not_to be_nil
-          expect(contributor_user.data.id).to eq @user.id.to_s
+          expect(Contributor.last.user).to eq @user
         end
 
         it "sets contributor project to specified project" do
-          contributor_project = json.data.relationships.project
-          expect(contributor_project).not_to be_nil
-          expect(contributor_project.data.id).to eq @project.id.to_s
+          expect(Contributor.last.project).to eq @project
         end
 
         it "sets contributor status to 'pending'" do
-          expect(json.data.attributes.status).to eq "pending"
-        end
-
-        it "includes the user" do
-          user_includes = json.included.select { |i| i.type == "users" }
-          expect(user_includes.count).to eq 1
-        end
-
-        it "includes the project" do
-          project_includes = json.included.select { |i| i.type == "projects" }
-          expect(project_includes.count).to eq 1
+          expect(Contributor.last.pending?).to be true
         end
       end
     end

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe ProjectSerializer, :type => :serializer do
 
   context "individual resource representation" do
-    let(:resource) { create(:project) }
+    let(:resource) { create(:project, :with_contributors, contributors_count: 5) }
 
     let(:serializer) { ProjectSerializer.new(resource) }
     let(:serialization) { ActiveModel::Serializer::Adapter.create(serializer) }
@@ -14,11 +14,15 @@ describe ProjectSerializer, :type => :serializer do
       end
 
       it "has an attributes object" do
-        expect(subject["attributes"]).not_to be nil
+        expect(subject["attributes"]).not_to be_nil
+      end
+
+      it "has a relationships object" do
+        expect(subject["relationships"]).not_to be_nil
       end
 
       it "has an id" do
-        expect(subject["id"]).not_to be nil
+        expect(subject["id"]).not_to be_nil
       end
 
       it "has a type set to 'projects'" do
@@ -39,6 +43,10 @@ describe ProjectSerializer, :type => :serializer do
       it "has a 'description'" do
         expect(subject["description"]).to eql resource.description
       end
+
+      it "has a 'contributors_count'" do
+        expect(subject["contributors_count"]).to eql resource.contributors_count
+      end
     end
 
     context "relationships" do
@@ -46,8 +54,9 @@ describe ProjectSerializer, :type => :serializer do
         JSON.parse(serialization.to_json)["data"]["relationships"]
       end
 
-      it "should be empty" do
-        expect(subject).to be_nil
+      it "should contain a 'contributors' relationship" do
+        expect(subject["contributors"]).not_to be_nil
+        expect(subject["contributors"]["data"].count).to eq 5
       end
     end
 


### PR DESCRIPTION
Closes #19 and #20 
# Note

Some of the changes here are minor and overlap with #78. They involve removing includes from the response for `POST /contributors`. Once #78 is merged and this branch is up to date, it will make more sense.
# Implementation

We already had counter cache implemented from #70, so this was just a matter of exposing it and the `has_many` relationship on the project serializer and writing specs to ensure this is the case.
