### PR TITLE
POST /organization endpoint

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,4 +1,5 @@
 class OrganizationsController < ApplicationController
+  before_action :doorkeeper_authorize!, only: [:create]
 
   def show
     organization = Organization.find(params[:id])
@@ -8,4 +9,21 @@ class OrganizationsController < ApplicationController
     render json: organization
   end
 
+  def create
+    authorize Organization
+
+    organization = Organization.new(create_params)
+
+    if organization.valid?
+      organization.save!
+      render json: organization
+    else
+      render_validation_errors organization.errors
+    end
+  end
+
+  private
+    def create_params
+      record_attributes.permit(:name)
+    end
 end

--- a/app/policies/organization_policy.rb
+++ b/app/policies/organization_policy.rb
@@ -9,4 +9,8 @@ class OrganizationPolicy
   def show?
     true
   end
+
+  def create?
+    user.admin?
+  end
 end


### PR DESCRIPTION
Closes #81 
# Implementation

Really straightfoward, nothing out of the ordinary.

Based on #81, the policy is that only admin users (`User#admin? == true`) are able to create organizations.

I'm not sure what was meant by validation here, so I didn't touch that yet.
