### PR TITLE
Added projects to user endpoint

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,10 +17,10 @@ class UsersController < ApplicationController
   end
 
   def show
-    user = User.includes(skills: [:skill_category]).find(params[:id])
+    user = User.includes(:projects, skills: :skill_category).find(params[:id])
 
     authorize user
-    render json: user, include: ["skills"]
+    render json: user, include: ["skills", "projects"]
   end
 
   def update
@@ -32,7 +32,7 @@ class UsersController < ApplicationController
   end
 
   def show_authenticated_user
-    render json: current_user, serializer: AuthenticatedUserSerializer
+    render json: current_user, serializer: AuthenticatedUserSerializer, include: ["projects"]
   end
 
   def update_authenticated_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,7 +32,7 @@ class UsersController < ApplicationController
   end
 
   def show_authenticated_user
-    render json: current_user, serializer: AuthenticatedUserSerializer, include: ["projects"]
+    render json: current_user, serializer: AuthenticatedUserSerializer
   end
 
   def update_authenticated_user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,6 @@ class User < ActiveRecord::Base
   has_many :organizations, through: :organization_memberships
   has_many :team_memberships, foreign_key: "member_id"
   has_many :teams, through: :team_memberships
-  has_many :projects, as: :owner
   has_many :posts
   has_many :comments
   has_many :user_skills

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,11 +16,14 @@ class User < ActiveRecord::Base
   has_many :following, through: :active_relationships, source: :following
   has_many :followers, through: :passive_relationships, source: :follower
 
+  has_many :contributors
+  has_many :projects, through: :contributors
+
   has_one :member, as: :model
 
   has_attached_file :photo,
                     styles: {
-                      large: "500x500#", 
+                      large: "500x500#",
                       thumb: "100x100#"
                     },
                     path: "users/:id/:style.:extension"

--- a/app/serializers/project_serializer_without_includes.rb
+++ b/app/serializers/project_serializer_without_includes.rb
@@ -1,0 +1,11 @@
+class ProjectSerializerWithoutIncludes < ActiveModel::Serializer
+  attributes :id, :title, :description, :icon_thumb_url, :icon_large_url, :contributors_count
+
+  def icon_thumb_url
+    object.icon.url(:thumb)
+  end
+
+  def icon_large_url
+    object.icon.url(:large)
+  end
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -2,6 +2,7 @@ class UserSerializer < ActiveModel::Serializer
   attributes :id, :email, :username, :twitter, :biography, :website, :facebook_id, :facebook_access_token, :photo_thumb_url, :photo_large_url
 
   has_many :skills
+  has_many :projects, serializer: ProjectSerializerWithoutIncludes
 
   def photo_thumb_url
     object.photo.url(:thumb)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -28,7 +28,6 @@ describe User, :type => :model do
     it { should have_many(:organizations).through(:organization_memberships) }
     it { should have_many(:team_memberships).with_foreign_key("member_id") }
     it { should have_many(:teams).through(:team_memberships) }
-    it { should have_many(:projects) }
     it { should have_many(:posts) }
     it { should have_many(:comments) }
     it { should have_many(:user_skills) }
@@ -38,6 +37,9 @@ describe User, :type => :model do
     it { should have_many(:following).through(:active_relationships).source(:following) }
     it { should have_many(:followers).through(:passive_relationships).source(:follower) }
     it { should have_one(:member) }
+
+    it { should have_many(:contributors) }
+    it { should have_many(:projects).through(:contributors) }
   end
 
   describe "validations" do
@@ -67,7 +69,7 @@ describe User, :type => :model do
         it { should validate_uniqueness_of(:username).case_insensitive }
         it { should validate_length_of(:username).is_at_most(39) }
       end
-      
+
       it { should allow_value("code_corps").for(:username) }
       it { should allow_value("codecorps").for(:username) }
       it { should allow_value("codecorps12345").for(:username) }

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -7,33 +7,29 @@ describe "Users API" do
   end
 
   context 'GET /user' do
-    let(:token) { authenticate(email: "josh@example.com", password: "password") }
-
-    before do
-      create(:user, email: "josh@example.com", username: "joshsmith", password: "password")
-    end
-
-    context 'when authenticated' do
-      it 'returns the authenticated user object' do
-        authenticated_get "user", {}, token
-
-        expect(last_response.status).to eq 200
-
-        user_attributes = json.data.attributes
-
-        expect(user_attributes.email).to eq "josh@example.com"
-        expect(user_attributes.username).to eq "joshsmith"
-        expect(user_attributes.password).to be_nil
-      end
-    end
-
     context 'when unauthenticated' do
-      it 'returns a 401 unauthorized' do
+      it 'returns a 401 NOT_AUTHORIZED' do
         get "#{host}/user"
 
         expect(last_response.status).to eq 401
-
         expect(json).to be_a_valid_json_api_error.with_id "NOT_AUTHORIZED"
+      end
+    end
+
+    context 'when authenticated' do
+      let(:token) { authenticate(email: "josh@example.com", password: "password") }
+
+      before do
+        @user = create(:user, email: "josh@example.com", username: "joshsmith", password: "password")
+        authenticated_get "user", {}, token
+      end
+
+      it "responds with a 200" do
+        expect(last_response.status).to eq 200
+      end
+
+      it 'returns the authenticated user object, serialized with AuthenticatedUserSerializer' do
+        expect(json).to serialize_object(@user).with(AuthenticatedUserSerializer)
       end
     end
   end
@@ -41,7 +37,8 @@ describe "Users API" do
   context 'GET /users/:id' do
     before do
       @user = create(:user, username: "joshsmith")
-      create_list(:user_skill, 10, user: @user)
+      create_list(:user_skill, 2, user: @user)
+      create_list(:contributor, 3, user: @user)
       get "#{host}/users/#{@user.id}"
     end
 
@@ -49,27 +46,8 @@ describe "Users API" do
       expect(last_response.status).to eq 200
     end
 
-    it "retrieves the specified user by id using UserSerializer, including skills" do
-      expect(json).to serialize_object(User.find(@user.id)).with(UserSerializer).with_includes("skills")
-      expect(json.data.id).to eq @user.id.to_s
-    end
-  end
-
-  context 'GET /users' do
-    before do
-      @user = create(:user, email: "josh@example.com", username: "joshsmith", password: "password")
-    end
-
-    it 'returns a user object if the user exists' do
-      get "#{host}/users/#{@user.id}",{}
-
-      expect(last_response.status).to eq 200
-
-      user_attributes = json.data.attributes
-
-      expect(user_attributes.email).to eq "josh@example.com"
-      expect(user_attributes.username).to eq "joshsmith"
-      expect(user_attributes.password).to be_nil
+    it "retrieves the specified user by id using UserSerializer, including skills and projects" do
+      expect(json).to serialize_object(User.find(@user.id)).with(UserSerializer).with_includes([:skills, :projects])
     end
   end
 
@@ -190,7 +168,7 @@ describe "Users API" do
 
         expect(json.errors[0].detail).to eq "Username may only contain alphanumeric characters, underscores, or single hyphens, and cannot begin or end with a hyphen or underscore"
       end
-      
+
       it 'fails on a username with profane content' do
         params = { email: "josh@example.com", username: "shit", password: "password" }
         json_api_params = json_api_params_for("users", params)
@@ -270,10 +248,10 @@ describe "Users API" do
         expect(last_response.status).to eq 200
 
         user = User.last
-      
+
         expect(user.username).to eq "joshsmith"
         expect(user.email).to eq "josh@example.com"
-        
+
         expect(UpdateProfilePictureWorker.jobs.size).to eq 0
       end
     end

--- a/spec/serializers/project_serializer_without_includes_spec.rb
+++ b/spec/serializers/project_serializer_without_includes_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+describe ProjectSerializerWithoutIncludes, :type => :serializer do
+
+  context "individual resource representation" do
+    let(:resource) {
+      project = create(:project, :with_contributors, contributors_count: 5)
+      create_list(:github_repository, 10, project: project)
+      project
+    }
+
+    let(:serializer) { ProjectSerializerWithoutIncludes.new(resource) }
+    let(:serialization) { ActiveModel::Serializer::Adapter.create(serializer) }
+
+    context "root" do
+      subject do
+        JSON.parse(serialization.to_json)["data"]
+      end
+
+      it "has an attributes object" do
+        expect(subject["attributes"]).not_to be_nil
+      end
+
+      it "does not have a relationships object" do
+        expect(subject["relationships"]).to be_nil
+      end
+
+      it "has an id" do
+        expect(subject["id"]).not_to be_nil
+      end
+
+      it "has a type set to 'projects'" do
+        expect(subject["type"]).to eq "projects"
+      end
+    end
+
+    context "attributes" do
+
+      subject do
+        JSON.parse(serialization.to_json)["data"]["attributes"]
+      end
+
+      it "has a 'title'" do
+        expect(subject["title"]).to eql resource.title
+      end
+
+      it "has a 'description'" do
+        expect(subject["description"]).to eql resource.description
+      end
+
+      it "has a 'contributors_count'" do
+        expect(subject["contributors_count"]).to eql resource.contributors_count
+      end
+    end
+  end
+end

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -12,7 +12,10 @@ describe UserSerializer, :type => :serializer do
         biography: "Lorem ipsum",
         facebook_id: "some_id",
         facebook_access_token: "some_token")
-      create_list(:user_skill, 10, user: user)
+
+      create_list(:user_skill, 2, user: user)
+      create_list(:contributor, 3, user: user)
+
       user
     }
 
@@ -82,7 +85,12 @@ describe UserSerializer, :type => :serializer do
 
       it "has a 'skills' relationship" do
         expect(subject["skills"]).not_to be_nil
-        expect(subject["skills"]["data"].count).to eq 10
+        expect(subject["skills"]["data"].count).to eq 2
+      end
+
+      it "has a 'projects' relationship" do
+        expect(subject["projects"]).not_to be_nil
+        expect(subject["projects"]["data"].count).to eq 3
       end
     end
 
@@ -106,7 +114,20 @@ describe UserSerializer, :type => :serializer do
 
         it "should contain the user's skills" do
           expect(subject).not_to be_nil
-          expect(subject.select{ |i| i["type"] == "skills"}.length).to eq 10
+          expect(subject.select{ |i| i["type"] == "skills"}.length).to eq 2
+        end
+      end
+
+      context "when including projects" do
+        let(:serialization) { ActiveModel::Serializer::Adapter.create(serializer, include: ["projects"]) }
+
+        subject do
+          JSON.parse(serialization.to_json)["included"]
+        end
+
+        it "should contain the user's projects" do
+          expect(subject).not_to be_nil
+          expect(subject.select{ |i| i["type"] == "projects"}.length).to eq 3
         end
       end
     end


### PR DESCRIPTION
Closes #28 

I added the info to the endpoint, but the whole thing is starting to get a bit unwieldy, in my opinion.

I had to add another serializer for projects - `ProjectSerializerWithoutIncludes`, meaning some duplicate code, duplicate specs and several extra tests.

I'm not really sure how to handle these issues, though. 

At the very least, I think we should change our naming convention and have something like `SimpleProjectSerializer` (for attributes only) and `FullProjectSerializer` (relationships to), which inherits from `SimpleProjectSerializer`.  This would dry up the code and the specs at least a little.

I looked into approaches for drying up things further, but I'm not finding much.
