### PR TITLE
Added GET /:slug/projects route

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -3,7 +3,13 @@ class ProjectsController < ApplicationController
 
   def index
     authorize Project
-    projects = Project.all.includes(:contributors, :github_repositories)
+
+    if for_member?
+      projects = find_projects_with_member!
+    else
+      projects = Project.all.includes(:contributors, :github_repositories)
+    end
+
     render json: projects
   end
 
@@ -82,9 +88,18 @@ class ProjectsController < ApplicationController
       params[:id]
     end
 
+    def for_member?
+      member_slug.present?
+    end
+
     def find_project_with_member!
       member = find_member!
       Project.includes(:contributors, :github_repositories).find_by!(slug: project_slug, owner: member.model)
+    end
+
+    def find_projects_with_member!
+      member = find_member!
+      Project.includes(:contributors, :github_repositories).where(owner: member.model)
     end
 
     def find_member!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
     resources :organizations, only: [:show, :create, :update]
 
     resources :members, :path => '', :only => [:show] do
+      get "projects", to: "projects#index"
       resources :projects, :path => '', :only => [:show]
     end
   end

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -23,6 +23,28 @@ describe "Projects API" do
 
   end
 
+  context "GET /:slug/projects" do
+    before do
+      @member = create(:organization).member
+      @projects = create_list(:project, 3, owner: @member.model)
+      create_list(:project, 2, owner: create(:organization))
+    end
+
+    context "when successful" do
+      before do
+        get "#{host}/#{@member.slug}/projects"
+      end
+
+      it "responds with a 200" do
+        expect(last_response.status).to eq 200
+      end
+
+      it "returns a list of projects for the specified member, serialized with ProjectSerializer" do
+        expect(json).to serialize_collection(@projects).with(ProjectSerializer)
+      end
+    end
+  end
+
   context "GET /:slug/:project_slug" do
     before do
       @project = create(:project, owner: create(:organization))

--- a/spec/support/matchers/serializer_matchers.rb
+++ b/spec/support/matchers/serializer_matchers.rb
@@ -30,7 +30,8 @@ RSpec::Matchers.define :serialize_collection do |collection|
 
     expected_json = cleanup JSON.parse(serialization.to_json options)
 
-    expected_json == actual_json
+    content_is_ok = arrays_have_same_elements(expected_json["data"], actual_json["data"])
+    content_is_ok and remainder_is_ok(expected_json, actual_json)
   end
 
   chain :with do |serializer_klass|
@@ -89,4 +90,15 @@ RSpec::Matchers.define :serialize_collection do |collection|
 
     { serialization_context: serialization_context }
   end
+
+  def arrays_have_same_elements a, b
+    a.to_set == b.to_set
+  end
+
+  def remainder_is_ok expected_json, actual_json
+    expected_json.delete(:data)
+    actual_json.delete(:data)
+    expected_json == actual_json
+  end
+
 end


### PR DESCRIPTION
Closes #97 

I'm making use of the existing `projects_controller#index` action, since I couldn't think of a more appropriate one. The action branches into fetching projects for the specified member if the member is specified, or fetching all projects if it is not (this was pre-exisiting behavior).

I had to improve on our `serialize_collection` matcher, so it compares the array properly, with indifference towards order in the array. 

If, at some point, we will require checking if the results are returned in proper order, then we will have to further expand the matcher to account for that option.
