### PR TITLE
Comment policy

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -2,18 +2,24 @@ class CommentsController < ApplicationController
   before_action :doorkeeper_authorize!, only: [:create, :update]
 
   def index
+    authorize Comments
+
     comments = Comment.where(post: params[:post_id])
     render json: comments
   end
 
   def show
     comment = Comment.find(params[:id])
+
+    authorize comment
+
     render json: comment
   end
 
   def create
-    authorize Comment
     comment = Comment.new(create_params)
+    authorize comment
+
     if comment.save
       GenerateCommentUserNotificationsWorker.perform_async(comment.id)
       render json: comment
@@ -24,6 +30,8 @@ class CommentsController < ApplicationController
 
   def update
     comment = Comment.find(params[:id])
+
+    authorize comment
 
     comment.assign_attributes(update_params)
 

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -6,7 +6,21 @@ class CommentPolicy
     @comment = comment
   end
 
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
   def create?
     user.present?
+  end
+
+  def update?
+    return false if user.nil?
+    return false if user != comment.user
+    return true
   end
 end

--- a/spec/policies/comment_policy_spec.rb
+++ b/spec/policies/comment_policy_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+describe CommentPolicy do
+
+  subject { described_class }
+
+
+  before do
+    @project = create(:project)
+
+    @author = create(:user)
+    @other_user = create(:user)
+
+    @comment = create(:comment, user: @author)
+  end
+
+  permissions :index? do
+    it "is permited for anyone" do
+      expect(subject).to permit(nil, Comment)
+    end
+  end
+
+  permissions :show? do
+    it "is permited for anyone" do
+      expect(subject).to permit(nil, Comment)
+    end
+  end
+
+  permissions :create? do
+    it "is not permitted for unauthenticated users" do
+      expect(subject).not_to permit(nil, Comment)
+    end
+
+    it "is permitted for authenticated users" do
+      expect(subject).to permit(@other_user, Comment)
+    end
+  end
+
+  permissions :update? do
+    it "is not permitted for unauthenticated users" do
+      expect(subject).not_to permit(nil, Comment)
+    end
+
+    it "is not permitted for authenticated users who did not create the comment" do
+      expect(subject).not_to permit(@other_user, @comment)
+    end
+
+    it "is permitted for authenticated users who did create the comment" do
+      expect(subject).to permit(@author, @comment)
+    end
+  end
+end

--- a/spec/requests/api/comments_spec.rb
+++ b/spec/requests/api/comments_spec.rb
@@ -275,6 +275,19 @@ describe "Comments API" do
           end
         end
       end
+
+      context "when updating another user's comment" do
+        before do
+          @comment = create(:comment, post: @post)
+        end
+
+        it "responds with a 401 ACCESS_DENIED" do
+          authenticated_patch "/comments/#{@comment.id}", { data: { type: "comments" } }, @token
+
+          expect(last_response.status).to eq 401
+          expect(json).to be_a_valid_json_api_error.with_id "ACCESS_DENIED"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #112 
# Implemented policy
- Anyone can `index`
- Anyone can `show`
- Any logged in user can `create`
- Only comment authors can `update` their own comments
