### PR TITLE
Add validation for attachment size to post, user, post_image, comment_image

### DIFF
--- a/app/models/comment_image.rb
+++ b/app/models/comment_image.rb
@@ -15,6 +15,8 @@ class CommentImage < ActiveRecord::Base
 
   validates :base64_photo_data, base64_photo_data: true
 
+  validates_attachment_size :image, less_than: 10.megabytes
+
   def decode_image_data
     return unless base64_photo_data.present?
     data = Paperclip.io_adapters.for(base64_photo_data)

--- a/app/models/post_image.rb
+++ b/app/models/post_image.rb
@@ -17,6 +17,8 @@ class PostImage < ActiveRecord::Base
 
   validates :base64_photo_data, base64_photo_data: true
 
+  validates_attachment_size :image, less_than: 10.megabytes
+
   def decode_image_data
     return unless base64_photo_data.present?
     data = Paperclip.io_adapters.for(base64_photo_data)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -24,6 +24,8 @@ class Project < ActiveRecord::Base
   validates_attachment_content_type :icon,
                                     content_type: %r{^image\/(png|gif|jpeg)}
 
+  validates_attachment_size :icon, less_than: 10.megabytes
+
 
   def decode_image_data
     return unless base64_icon_data.present?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,8 @@ class User < ActiveRecord::Base
   validates_attachment_content_type :photo,
                                     content_type: %r{^image\/(png|gif|jpeg)}
 
+  validates_attachment_size :photo, less_than: 10.megabytes
+
   validates :username, presence: { message: "can't be blank" }, obscenity: {message: "may not be obscene"}
   validates :username, exclusion: { in: Rails.configuration.x.reserved_routes }
   validates :username, slug: true

--- a/spec/models/comment_image_spec.rb
+++ b/spec/models/comment_image_spec.rb
@@ -33,6 +33,10 @@ RSpec.describe CommentImage, type: :model do
 
     it { should allow_value(gif_string).for(:base64_photo_data) }
     it { should_not allow_value(jpeg_without_data_string).for(:base64_photo_data) }
+
+    context "paperclip", vcr: { cassette_name: 'models/comment_image/validation' } do
+      it { should validate_attachment_size(:image).less_than(10.megabytes) }
+    end
   end
 
   context 'paperclip' do

--- a/spec/models/comment_image_spec.rb
+++ b/spec/models/comment_image_spec.rb
@@ -42,12 +42,13 @@ RSpec.describe CommentImage, type: :model do
   context "paperclip" do
     context "without cloudfront" do
       it { should have_attached_file(:image) }
-      it { should validate_attachment_content_type(:image)
-          .allowing("image/png", "image/gif", "image/jpeg")
-          .rejecting("text/plain", "text/xml") }
+      it { should validate_attachment_content_type(:image).
+        allowing("image/png", "image/gif", "image/jpeg").
+        rejecting("text/plain", "text/xml")
+      }
     end
 
-    context "with cloudfront"  do
+    context "with cloudfront" do
       let(:comment) { create(:comment, id: 1) }
       let(:comment_image) { create(:comment_image, :with_s3_image, id: 1, comment: comment, filename: "default-avatar.gif", base64_photo_data: gif_string) }
 

--- a/spec/models/comment_image_spec.rb
+++ b/spec/models/comment_image_spec.rb
@@ -1,13 +1,13 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe CommentImage, type: :model do
   let(:gif_string) {
-    file = File.open("#{Rails.root}/spec/sample_data/base64_images/gif.txt", 'r')
+    file = File.open("#{Rails.root}/spec/sample_data/base64_images/gif.txt", "r")
     open(file) { |io| io.read }
   }
 
   let(:jpeg_without_data_string) {
-    file = File.open("#{Rails.root}/spec/sample_data/base64_images/jpeg_without_data_string.txt", 'r')
+    file = File.open("#{Rails.root}/spec/sample_data/base64_images/jpeg_without_data_string.txt", "r")
     open(file) { |io| io.read }
   }
 
@@ -34,29 +34,29 @@ RSpec.describe CommentImage, type: :model do
     it { should allow_value(gif_string).for(:base64_photo_data) }
     it { should_not allow_value(jpeg_without_data_string).for(:base64_photo_data) }
 
-    context "paperclip", vcr: { cassette_name: 'models/comment_image/validation' } do
+    context "paperclip", vcr: { cassette_name: "models/comment_image/validation" } do
       it { should validate_attachment_size(:image).less_than(10.megabytes) }
     end
   end
 
-  context 'paperclip' do
-    context 'without cloudfront' do
+  context "paperclip" do
+    context "without cloudfront" do
       it { should have_attached_file(:image) }
       it { should validate_attachment_content_type(:image)
-          .allowing('image/png', 'image/gif', 'image/jpeg')
-          .rejecting('text/plain', 'text/xml') }
+          .allowing("image/png", "image/gif", "image/jpeg")
+          .rejecting("text/plain", "text/xml") }
     end
 
-    context 'with cloudfront'  do
+    context "with cloudfront"  do
       let(:comment) { create(:comment, id: 1) }
       let(:comment_image) { create(:comment_image, :with_s3_image, id: 1, comment: comment, filename: "default-avatar.gif", base64_photo_data: gif_string) }
 
-      it 'should have our cloudfront domain in the URL', vcr: { cassette_name: 'models/comment_image/aws-upload' } do
+      it "should have our cloudfront domain in the URL", vcr: { cassette_name: "models/comment_image/aws-upload" } do
         comment_image.decode_image_data
-        expect(comment_image.image.url).to include ENV['CLOUDFRONT_DOMAIN']
+        expect(comment_image.image.url).to include ENV["CLOUDFRONT_DOMAIN"]
       end
 
-      it 'should have the right path', vcr: { cassette_name: 'models/comment_image/aws-upload' } do
+      it "should have the right path", vcr: { cassette_name: "models/comment_image/aws-upload" } do
         comment_image.decode_image_data
         expect(comment_image.image.url).to include "comments/#{comment.id}/images/#{comment_image.id}/original.gif"
       end

--- a/spec/models/post_image_spec.rb
+++ b/spec/models/post_image_spec.rb
@@ -42,12 +42,13 @@ RSpec.describe PostImage, type: :model do
   context "paperclip" do
     context "without cloudfront" do
       it { should have_attached_file(:image) }
-      it { should validate_attachment_content_type(:image)
-          .allowing("image/png", "image/gif", "image/jpeg")
-          .rejecting("text/plain", "text/xml") }
+      it { should validate_attachment_content_type(:image).
+        allowing("image/png", "image/gif", "image/jpeg").
+        rejecting("text/plain", "text/xml")
+      }
     end
 
-    context "with cloudfront"  do
+    context "with cloudfront" do
       let(:post) { create(:post, id: 1) }
       let(:post_image) { create(:post_image, :with_s3_image, id: 1, post: post, filename: "default-avatar.gif", base64_photo_data: gif_string) }
 

--- a/spec/models/post_image_spec.rb
+++ b/spec/models/post_image_spec.rb
@@ -33,6 +33,10 @@ RSpec.describe PostImage, type: :model do
 
     it { should allow_value(gif_string).for(:base64_photo_data) }
     it { should_not allow_value(jpeg_without_data_string).for(:base64_photo_data) }
+
+    context "paperclip", vcr: { cassette_name: 'models/post_image/validation' } do
+      it { should validate_attachment_size(:image).less_than(10.megabytes) }
+    end
   end
 
   context 'paperclip' do

--- a/spec/models/post_image_spec.rb
+++ b/spec/models/post_image_spec.rb
@@ -1,13 +1,13 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe PostImage, type: :model do
   let(:gif_string) {
-    file = File.open("#{Rails.root}/spec/sample_data/base64_images/gif.txt", 'r')
+    file = File.open("#{Rails.root}/spec/sample_data/base64_images/gif.txt", "r")
     open(file) { |io| io.read }
   }
 
   let(:jpeg_without_data_string) {
-    file = File.open("#{Rails.root}/spec/sample_data/base64_images/jpeg_without_data_string.txt", 'r')
+    file = File.open("#{Rails.root}/spec/sample_data/base64_images/jpeg_without_data_string.txt", "r")
     open(file) { |io| io.read }
   }
 
@@ -34,29 +34,29 @@ RSpec.describe PostImage, type: :model do
     it { should allow_value(gif_string).for(:base64_photo_data) }
     it { should_not allow_value(jpeg_without_data_string).for(:base64_photo_data) }
 
-    context "paperclip", vcr: { cassette_name: 'models/post_image/validation' } do
+    context "paperclip", vcr: { cassette_name: "models/post_image/validation" } do
       it { should validate_attachment_size(:image).less_than(10.megabytes) }
     end
   end
 
-  context 'paperclip' do
-    context 'without cloudfront' do
+  context "paperclip" do
+    context "without cloudfront" do
       it { should have_attached_file(:image) }
       it { should validate_attachment_content_type(:image)
-          .allowing('image/png', 'image/gif', 'image/jpeg')
-          .rejecting('text/plain', 'text/xml') }
+          .allowing("image/png", "image/gif", "image/jpeg")
+          .rejecting("text/plain", "text/xml") }
     end
 
-    context 'with cloudfront'  do
+    context "with cloudfront"  do
       let(:post) { create(:post, id: 1) }
       let(:post_image) { create(:post_image, :with_s3_image, id: 1, post: post, filename: "default-avatar.gif", base64_photo_data: gif_string) }
 
-      it 'should have our cloudfront domain in the URL', vcr: { cassette_name: 'models/post_image/aws-upload' } do
+      it "should have our cloudfront domain in the URL", vcr: { cassette_name: "models/post_image/aws-upload" } do
         post_image.decode_image_data
-        expect(post_image.image.url).to include ENV['CLOUDFRONT_DOMAIN']
+        expect(post_image.image.url).to include ENV["CLOUDFRONT_DOMAIN"]
       end
 
-      it 'should have the right path', vcr: { cassette_name: 'models/post_image/aws-upload' } do
+      it "should have the right path", vcr: { cassette_name: "models/post_image/aws-upload" } do
         post_image.decode_image_data
         expect(post_image.image.url).to include "posts/#{post.id}/images/#{post_image.id}/original.gif"
       end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -109,7 +109,7 @@ describe Project, :type => :model do
   context "paperclip" do
     context "without cloudfront" do
       it { should have_attached_file(:icon) }
-      it { should validate_attachment_content_type(:photo).
+      it { should validate_attachment_content_type(:icon).
         allowing("image/png", "image/gif", "image/jpeg").
         rejecting("text/plain", "text/xml")
       }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -25,7 +25,6 @@ describe Project, :type => :model do
       it { should validate_attachment_size(:icon).less_than(10.megabytes) }
     end
 
-
     describe "title" do
       describe "base validations" do
         # visit the following to understand why this is tested in a separate context
@@ -110,9 +109,10 @@ describe Project, :type => :model do
   context "paperclip" do
     context "without cloudfront" do
       it { should have_attached_file(:icon) }
-      it { should validate_attachment_content_type(:icon)
-          .allowing("image/png", "image/gif", "image/jpeg")
-          .rejecting("text/plain", "text/xml") }
+      it { should validate_attachment_content_type(:image).
+        allowing("image/png", "image/gif", "image/jpeg").
+        rejecting("text/plain", "text/xml")
+      }
     end
 
     context "with cloudfront" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -109,7 +109,7 @@ describe Project, :type => :model do
   context "paperclip" do
     context "without cloudfront" do
       it { should have_attached_file(:icon) }
-      it { should validate_attachment_content_type(:image).
+      it { should validate_attachment_content_type(:photo).
         allowing("image/png", "image/gif", "image/jpeg").
         rejecting("text/plain", "text/xml")
       }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe Project, :type => :model do
   describe "schema" do
@@ -21,7 +21,7 @@ describe Project, :type => :model do
 
   describe "validations" do
 
-    context "paperclip", vcr: { cassette_name: 'models/project/validation' } do
+    context "paperclip", vcr: { cassette_name: "models/project/validation" } do
       it { should validate_attachment_size(:icon).less_than(10.megabytes) }
     end
 
@@ -107,23 +107,23 @@ describe Project, :type => :model do
     end
   end
 
-  context 'paperclip' do
-    context 'without cloudfront' do
+  context "paperclip" do
+    context "without cloudfront" do
       it { should have_attached_file(:icon) }
       it { should validate_attachment_content_type(:icon)
-          .allowing('image/png', 'image/gif', 'image/jpeg')
-          .rejecting('text/plain', 'text/xml') }
+          .allowing("image/png", "image/gif", "image/jpeg")
+          .rejecting("text/plain", "text/xml") }
     end
 
-    context 'with cloudfront' do
+    context "with cloudfront" do
 
       let(:project) { create(:project, :with_s3_icon) }
 
-      it 'should have our cloudfront domain in the URL' do
-        expect(project.icon.url(:thumb)).to include ENV['CLOUDFRONT_DOMAIN']
+      it "should have our cloudfront domain in the URL" do
+        expect(project.icon.url(:thumb)).to include ENV["CLOUDFRONT_DOMAIN"]
       end
 
-      it 'should have the right path' do
+      it "should have the right path" do
         expect(project.icon.url(:thumb)).to include "projects/#{project.id}/thumb"
       end
     end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -21,6 +21,11 @@ describe Project, :type => :model do
 
   describe "validations" do
 
+    context "paperclip", vcr: { cassette_name: 'models/project/validation' } do
+      it { should validate_attachment_size(:icon).less_than(10.megabytes) }
+    end
+
+
     describe "title" do
       describe "base validations" do
         # visit the following to understand why this is tested in a separate context

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -43,6 +43,10 @@ describe User, :type => :model do
   end
 
   describe "validations" do
+    context "paperclip", vcr: { cassette_name: 'models/user/validation' } do
+      it { should validate_attachment_size(:photo).less_than(10.megabytes) }
+    end
+
 
     describe "website" do
       it { should allow_value("www.example.com").for(:website) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -146,7 +146,7 @@ describe User, :type => :model do
   context "paperclip" do
     context "without cloudfront" do
       it { should have_attached_file(:photo) }
-      it { should validate_attachment_content_type(:image).
+      it { should validate_attachment_content_type(:photo).
         allowing("image/png", "image/gif", "image/jpeg").
         rejecting("text/plain", "text/xml")
       }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -146,9 +146,10 @@ describe User, :type => :model do
   context "paperclip" do
     context "without cloudfront" do
       it { should have_attached_file(:photo) }
-      it { should validate_attachment_content_type(:photo)
-          .allowing("image/png", "image/gif", "image/jpeg")
-          .rejecting("text/plain", "text/xml") }
+      it { should validate_attachment_content_type(:image).
+        allowing("image/png", "image/gif", "image/jpeg").
+        rejecting("text/plain", "text/xml")
+      }
     end
 
     context "with cloudfront" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe User, :type => :model do
 
@@ -43,7 +43,7 @@ describe User, :type => :model do
   end
 
   describe "validations" do
-    context "paperclip", vcr: { cassette_name: 'models/user/validation' } do
+    context "paperclip", vcr: { cassette_name: "models/user/validation" } do
       it { should validate_attachment_size(:photo).less_than(10.megabytes) }
     end
 
@@ -143,28 +143,28 @@ describe User, :type => :model do
     end
   end
 
-  context 'paperclip' do
-    context 'without cloudfront' do
+  context "paperclip" do
+    context "without cloudfront" do
       it { should have_attached_file(:photo) }
       it { should validate_attachment_content_type(:photo)
-          .allowing('image/png', 'image/gif', 'image/jpeg')
-          .rejecting('text/plain', 'text/xml') }
+          .allowing("image/png", "image/gif", "image/jpeg")
+          .rejecting("text/plain", "text/xml") }
     end
 
-    context 'with cloudfront' do
+    context "with cloudfront" do
       let(:user) { create(:user, :with_s3_photo) }
 
-      it 'should have our cloudfront domain in the URL' do
-        expect(user.photo.url(:thumb)).to include ENV['CLOUDFRONT_DOMAIN']
+      it "should have our cloudfront domain in the URL" do
+        expect(user.photo.url(:thumb)).to include ENV["CLOUDFRONT_DOMAIN"]
       end
 
-      it 'should have the right path' do
+      it "should have the right path" do
         expect(user.photo.url(:thumb)).to include "users/#{user.id}/thumb"
       end
     end
   end
 
-  context 'following behavior' do
+  context "following behavior" do
     before(:each) do
       @user = create(:user)
       @other_user_1 = create(:user)

--- a/spec/vcr/models/comment_image/validation.yml
+++ b/spec/vcr/models/comment_image/validation.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: https://code-corps-development.s3.amazonaws.com/comments//images//original.
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.2.5 ruby/2.2.3 x86_64-linux resources
+      X-Amz-Date:
+      - 20151215T150217Z
+      Host:
+      - code-corps-development.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=AKIAJA5VYNIZZFUPOAKA/20151215/us-east-1/s3/aws4_request,
+        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=38361f27966472cd590ead500856bcccadcbd3f6cf6ae1d3457f3e2810cde502
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      X-Amz-Request-Id:
+      - 664AB6FC0D188A15
+      X-Amz-Id-2:
+      - sjzlJHWuSMOfO9qgNTwmSIdC8ZqzTzRDBceohg+GnMovdFulgO+fNDmcZIGrOu4tjseIlKSUap0=
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Tue, 15 Dec 2015 15:02:15 GMT
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 15 Dec 2015 15:02:18 GMT
+recorded_with: VCR 3.0.0

--- a/spec/vcr/models/post_image/validation.yml
+++ b/spec/vcr/models/post_image/validation.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: https://code-corps-development.s3.amazonaws.com/posts//images//original.
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.2.5 ruby/2.2.3 x86_64-linux resources
+      X-Amz-Date:
+      - 20151215T150259Z
+      Host:
+      - code-corps-development.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=AKIAJA5VYNIZZFUPOAKA/20151215/us-east-1/s3/aws4_request,
+        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=509326738279533fc62ac61c6019979c12b711b8e2c71b88eb75525597533cd4
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      X-Amz-Request-Id:
+      - 63B1DDA5407B74BC
+      X-Amz-Id-2:
+      - xn08IsFMN36tsDJKrcsXu44YS/pvuPWVQ90rIpOZeFoknQep1lRbkOKy/wT+qKx7
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Tue, 15 Dec 2015 15:02:56 GMT
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 15 Dec 2015 15:03:00 GMT
+recorded_with: VCR 3.0.0

--- a/spec/vcr/models/project/validation.yml
+++ b/spec/vcr/models/project/validation.yml
@@ -1,0 +1,147 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: https://code-corps-development.s3.amazonaws.com/projects//original.
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.2.5 ruby/2.2.3 x86_64-linux resources
+      X-Amz-Date:
+      - 20151215T150403Z
+      Host:
+      - code-corps-development.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=AKIAJA5VYNIZZFUPOAKA/20151215/us-east-1/s3/aws4_request,
+        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=9ec39f0f6ae26df3194c50e298fdea7ee6bed86a6c1309dd4640abba74ea018d
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      X-Amz-Request-Id:
+      - F5E456A13F8DE33E
+      X-Amz-Id-2:
+      - 1nxbweX4Ej9wIK/1vOMlzq/dKAPCCQ77nqdiEY5vYkPEqYnUa4QZi0NMiD+FeOB9MqEq7TEn1J4=
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Tue, 15 Dec 2015 15:04:01 GMT
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 15 Dec 2015 15:04:05 GMT
+- request:
+    method: head
+    uri: https://code-corps-development.s3.amazonaws.com/projects//large.
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.2.5 ruby/2.2.3 x86_64-linux resources
+      X-Amz-Date:
+      - 20151215T150405Z
+      Host:
+      - code-corps-development.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=AKIAJA5VYNIZZFUPOAKA/20151215/us-east-1/s3/aws4_request,
+        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=c8e3537f949c8ce10bd0cefe948bec406973aae397b387ea1b5f5b4aece9103c
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      X-Amz-Request-Id:
+      - 888D82FE933500D0
+      X-Amz-Id-2:
+      - d0VJ1u3ykquRrH+khODbviUT1aQgisuEN6FiLqVPPLbnP8Rtz3Hjnuc8bJsbg4A0MawVnrJNQ3Y=
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Tue, 15 Dec 2015 15:04:02 GMT
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 15 Dec 2015 15:04:06 GMT
+- request:
+    method: head
+    uri: https://code-corps-development.s3.amazonaws.com/projects//thumb.
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.2.5 ruby/2.2.3 x86_64-linux resources
+      X-Amz-Date:
+      - 20151215T150406Z
+      Host:
+      - code-corps-development.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=AKIAJA5VYNIZZFUPOAKA/20151215/us-east-1/s3/aws4_request,
+        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=4c09ac3fa4435bceb001f984d2febfb2cc565f4fe02709c88cd7adf3c1c8e93b
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      X-Amz-Request-Id:
+      - 7645F483D4A009EC
+      X-Amz-Id-2:
+      - wCJ+30JvjgOXpmsjUBEkAOMdkWuaMLi1Db2cgnsTFNLb5ODRMKRXYdMEh3cCbCTzY1vuU6eTxVc=
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Tue, 15 Dec 2015 15:04:03 GMT
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 15 Dec 2015 15:04:07 GMT
+recorded_with: VCR 3.0.0

--- a/spec/vcr/models/user/validation.yml
+++ b/spec/vcr/models/user/validation.yml
@@ -1,0 +1,147 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: https://code-corps-development.s3.amazonaws.com/users//original.
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.2.5 ruby/2.2.3 x86_64-linux resources
+      X-Amz-Date:
+      - 20151215T150408Z
+      Host:
+      - code-corps-development.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=AKIAJA5VYNIZZFUPOAKA/20151215/us-east-1/s3/aws4_request,
+        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=d6c1dceba53461dfe55436e8050bbda44e175150645c8207f58f45082078a7de
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      X-Amz-Request-Id:
+      - 2A57E47D4E45A3D1
+      X-Amz-Id-2:
+      - wO5jAYQYqVqGuy4cRooRMYv5nRxq6Oewf8FJghidj6LAAQfIOPA3QXwF6g0Ywi/0
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Tue, 15 Dec 2015 15:04:05 GMT
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 15 Dec 2015 15:04:09 GMT
+- request:
+    method: head
+    uri: https://code-corps-development.s3.amazonaws.com/users//large.
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.2.5 ruby/2.2.3 x86_64-linux resources
+      X-Amz-Date:
+      - 20151215T150409Z
+      Host:
+      - code-corps-development.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=AKIAJA5VYNIZZFUPOAKA/20151215/us-east-1/s3/aws4_request,
+        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=c974011db621baffd703c5f442a4c30ca56c4a6c661847e79156992535e34360
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      X-Amz-Request-Id:
+      - 4EA731A3AD22E15B
+      X-Amz-Id-2:
+      - 54u3HoWlgvPJDlGECCbBd5/0UVHYyhciwhDT9IV6hQ9p7yadZ/1QBclvY5aXG1bf
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Tue, 15 Dec 2015 15:04:07 GMT
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 15 Dec 2015 15:04:10 GMT
+- request:
+    method: head
+    uri: https://code-corps-development.s3.amazonaws.com/users//thumb.
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.2.5 ruby/2.2.3 x86_64-linux resources
+      X-Amz-Date:
+      - 20151215T150410Z
+      Host:
+      - code-corps-development.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=AKIAJA5VYNIZZFUPOAKA/20151215/us-east-1/s3/aws4_request,
+        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=cc82b754af45b9488b54199611a5857170850960e243afc69ca91d9389a96779
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      X-Amz-Request-Id:
+      - 57BFF264AAE7219D
+      X-Amz-Id-2:
+      - 34JBnUcWRcz3ww1wdeuFMypmKGVq9OjGGzcUZA7qSAx2cioxz9nvALVR695gDV2z
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Tue, 15 Dec 2015 15:04:08 GMT
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 15 Dec 2015 15:04:12 GMT
+recorded_with: VCR 3.0.0


### PR DESCRIPTION
Closes #132 

I used paperclips shoulda matches, which are already available to us. Attachment size is limited to 10 mb.

I'm not liking the fact that again, paperclip is doing a HEAD request to the image url for some reason, so I had to wrap the specs with VCR. 
