### PR TITLE
Presence validation and spec for post_type

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -21,6 +21,7 @@ class Post < ActiveRecord::Base
   validates_presence_of :title
   validates_presence_of :body
   validates_presence_of :markdown
+  validates_presence_of :post_type
 
   validates_uniqueness_of :number, scope: :project_id, allow_nil: true
 

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -31,6 +31,7 @@ describe Post, :type => :model do
     it { should validate_presence_of(:title) }
     it { should validate_presence_of(:body) }
     it { should validate_presence_of(:markdown) }
+    it { should validate_presence_of(:post_type) }
 
     context "number" do
       let(:subject) { create(:post) }


### PR DESCRIPTION
Closes #165 

The only validation I added is one that prevents nil values. I explained why there is no need or a way to add anything else in an https://github.com/code-corps/code-corps-api/issues/165#issuecomment-172487860
