### PR TITLE
Fixed seed_fu

### DIFF
--- a/db/fixtures/users.rb
+++ b/db/fixtures/users.rb
@@ -1,6 +1,6 @@
 User.seed do |user|
   user.id        = 1
-  user.username  = "admin"
+  user.username  = "administrator"
   user.email     = "admin@example.org"
   user.password  = "password"
   user.admin     = true


### PR DESCRIPTION
Closes #149

Fixed `rake:seed_fu` by changing admin user's username from "admin", which is a reserved word, to "administrator".
