### PR TITLE
Make tests less ENV dependant

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,7 +5,7 @@ CodeClimate::TestReporter.start
 ENV["RAILS_ENV"] ||= 'test'
 
 ENV["S3_BUCKET_NAME"] ||= "test_bucket"
-ENV["CLOUDFRONT_DOMAIN"] ||= "test.cloufront.com"
+ENV["CLOUDFRONT_DOMAIN"] ||= "test.cloudfront.com"
 
 require 'spec_helper'
 require File.expand_path("../../config/environment", __FILE__)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,6 +3,10 @@ CodeClimate::TestReporter.start
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= 'test'
+
+ENV["S3_BUCKET_NAME"] ||= "test_bucket"
+ENV["CLOUDFRONT_DOMAIN"] ||= "test.cloufront.com"
+
 require 'spec_helper'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'


### PR DESCRIPTION
This is part of a solution for #150 and with that, #152 

When renaming or deleting a proper .env file, 19 tests fail to pass
- 8 fail due to missing `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
- 2 fail due to missing `S3_BUCKET_NAME` and `CLOUDFRONT_DOMAIN`
- 9 fail due to missing `FACEBOOK_APP_ID` and `FACEBOOK_APP_SECRET`

Adding 

``` Ruby
ENV["S3_BUCKET_NAME"] ||= "test_bucket"
ENV["CLOUDFRONT_DOMAIN"] ||= "test.cloufront.com"
```

to `spec/rails_helper.rb` makes the two related tests pass. We can move this to a separate file for cleaner code, but I think this is the way to go for these types of tests. They aren't actually checking web requests - they just test some related behavior, so the values only need to be present, not valid.

**For tests involving Facebook**, I don't see any mocking options for Koala, which is the gem we're using. I think the best course of action in this case would be to define a `FacebookGateway` class which uses Koala internally.

Then we can mock the gateway class for most of our tests and write tests for the class itself, which will then be in one place and can be explicitly skipped more easily if the required ENV variables are missing.

**For tests involving AWS credentials**, since those are used by Paperclip internally, we would likely have to somehow stub paperclip instance methods so they don't access the web at all. I don't think we can go with a gateway approach.

Note that for the test-skipping part of the whole thing, we already have a PR awaiting merge at #153. I think we should be fine with merging that for now and expanding on it.
