### PR TITLE
Add preview fields for body and markdown

### DIFF
--- a/app/serializers/comment_serializer.rb
+++ b/app/serializers/comment_serializer.rb
@@ -15,7 +15,9 @@
 #
 
 class CommentSerializer < ActiveModel::Serializer
-  attributes :id, :body, :markdown, :state, :edited_at
+  attributes :id, :state,
+             :body, :body_preview, :markdown, :markdown_preview,
+             :edited_at
 
   belongs_to :post
   belongs_to :user

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -21,8 +21,10 @@
 #
 
 class PostSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :status, :post_type, :likes_count, :markdown,
-             :number, :state, :edited_at, :comments_count
+  attributes :id, :number, :post_type, :state, :status,
+             :title, :body, :body_preview, :markdown, :markdown_preview,
+             :likes_count, :comments_count,
+             :edited_at
 
   has_many :comments
   has_many :post_user_mentions

--- a/db/fixtures/002_organizations.rb
+++ b/db/fixtures/002_organizations.rb
@@ -3,3 +3,9 @@ Organization.seed do |organization|
   organization.name = "Code Corps"
   organization.slug = "code_corps"
 end
+
+OrganizationMembership.seed do |membership|
+  membership.id = 1
+  membership.member_id = 2
+  membership.organization_id = 1
+end

--- a/db/fixtures/004_posts.rb
+++ b/db/fixtures/004_posts.rb
@@ -2,7 +2,9 @@
   Post.seed do |post|
     post.title = "A task"
     post.body = "This is a basic task"
+    post.body_preview = "This is a basic task"
     post.markdown = "This is a basic task"
+    post.markdown_preview = "This is a basic task"
     post.project_id = 1
     post.user_id = 2
     post.post_type = "task"
@@ -12,7 +14,9 @@
   Post.seed do |post|
     post.title = "An idea"
     post.body = "This is a basic idea"
+    post.body_preview = "This is a basic idea"
     post.markdown = "This is a basic idea"
+    post.markdown_preview = "This is a basic idea"
     post.project_id = 1
     post.user_id = 2
     post.post_type = "idea"
@@ -22,7 +26,9 @@
   Post.seed do |post|
     post.title = "A progress post"
     post.body = "This is a basic progress post"
+    post.body_preview = "This is a basic progress post"
     post.markdown = "This is a basic progress post"
+    post.markdown_preview = "This is a basic progress post"
     post.project_id = 1
     post.user_id = 2
     post.post_type = "progress"
@@ -32,7 +38,9 @@
   Post.seed do |post|
     post.title = "An issue"
     post.body = "This is a basic issue"
-    post.markdown = "This is a basic issue"
+    post.body_preview = "This is a basic issue"
+    post.markdown = "This is a basic progress post"
+    post.markdown_preview = "This is a basic progress post"
     post.project_id = 1
     post.user_id = 2
     post.post_type = "issue"

--- a/db/migrate/20160209170316_add_body_preview_markdown_preview_to_posts.rb
+++ b/db/migrate/20160209170316_add_body_preview_markdown_preview_to_posts.rb
@@ -1,0 +1,8 @@
+class AddBodyPreviewMarkdownPreviewToPosts < ActiveRecord::Migration
+  def change
+    add_column :posts, :body_preview, :text, null: true
+    add_column :posts, :markdown_preview, :text, null: true
+    change_column_null :posts, :body, true
+    change_column_null :posts, :markdown, true
+  end
+end

--- a/db/migrate/20160210140342_add_body_preview_markdown_preview_to_comments.rb
+++ b/db/migrate/20160210140342_add_body_preview_markdown_preview_to_comments.rb
@@ -1,0 +1,8 @@
+class AddBodyPreviewMarkdownPreviewToComments < ActiveRecord::Migration
+  def change
+    add_column :comments, :body_preview, :text, null: true
+    add_column :comments, :markdown_preview, :text, null: true
+    change_column_null :comments, :body, true
+    change_column_null :comments, :markdown, true
+  end
+end

--- a/db/migrate/20160212102442_allow_null_on_post_title.rb
+++ b/db/migrate/20160212102442_allow_null_on_post_title.rb
@@ -1,0 +1,5 @@
+class AllowNullOnPostTitle < ActiveRecord::Migration
+  def change
+    change_column_null :posts, :title, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -41,13 +41,15 @@ ActiveRecord::Schema.define(version: 20160215223422) do
   end
 
   create_table "comments", force: :cascade do |t|
-    t.text     "body",       null: false
-    t.integer  "user_id",    null: false
-    t.integer  "post_id",    null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.text     "markdown",   null: false
+    t.text     "body"
+    t.integer  "user_id",          null: false
+    t.integer  "post_id",          null: false
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
+    t.text     "markdown"
     t.string   "aasm_state"
+    t.text     "body_preview"
+    t.text     "markdown_preview"
   end
 
   create_table "github_repositories", force: :cascade do |t|
@@ -168,17 +170,19 @@ ActiveRecord::Schema.define(version: 20160215223422) do
   create_table "posts", force: :cascade do |t|
     t.string   "status",           default: "open"
     t.string   "post_type",        default: "task"
-    t.string   "title",                             null: false
-    t.text     "body",                              null: false
+    t.string   "title"
+    t.text     "body"
     t.integer  "user_id",                           null: false
     t.integer  "project_id",                        null: false
     t.datetime "created_at",                        null: false
     t.datetime "updated_at",                        null: false
     t.integer  "post_likes_count", default: 0
-    t.text     "markdown",                          null: false
+    t.text     "markdown"
     t.integer  "number"
     t.string   "aasm_state"
     t.integer  "comments_count",   default: 0
+    t.text     "body_preview"
+    t.text     "markdown_preview"
   end
 
   create_table "projects", force: :cascade do |t|

--- a/lib/code_corps/scenario/generate_user_mentions_for_comment.rb
+++ b/lib/code_corps/scenario/generate_user_mentions_for_comment.rb
@@ -10,7 +10,7 @@ module CodeCorps
         result = []
         mentions = []
 
-        @comment.body.scan(/\B@((?:(?:(?:[^-\W]-?))*)(?:[^\/\W]\/?)?(?:(?:(?:[^-\W]-?))*)\w+)/) do |temp|
+        @comment.body_preview.scan(/\B@((?:(?:(?:[^-\W]-?))*)(?:[^\/\W]\/?)?(?:(?:(?:[^-\W]-?))*)\w+)/) do |temp|
           username = temp.first
           start_index = Regexp.last_match.offset(0).first
           end_index = start_index + username.length
@@ -37,6 +37,6 @@ module CodeCorps
           end
         end
       end
-    end 
+    end
   end
 end

--- a/lib/code_corps/scenario/generate_user_mentions_for_post.rb
+++ b/lib/code_corps/scenario/generate_user_mentions_for_post.rb
@@ -9,7 +9,7 @@ module CodeCorps
         result = []
         mentions = []
 
-        @post.body.scan(/\B@((?:(?:(?:[^-\W]-?))*)(?:[^\/\W]\/?)?(?:(?:(?:[^-\W]-?))*)\w+)/) do |temp|
+        @post.body_preview.scan(/\B@((?:(?:(?:[^-\W]-?))*)(?:[^\/\W]\/?)?(?:(?:(?:[^-\W]-?))*)\w+)/) do |temp|
           username = temp.first
           start_index = Regexp.last_match.offset(0).first
           end_index = start_index + username.length
@@ -36,6 +36,6 @@ module CodeCorps
           end
         end
       end
-    end 
+    end
   end
 end

--- a/spec/factories/comment_factory.rb
+++ b/spec/factories/comment_factory.rb
@@ -18,15 +18,42 @@ FactoryGirl.define do
 
   factory :comment do
     sequence(:markdown) { |n| "Comment #{n}" }
+    sequence(:markdown_preview) { |n| "Comment #{n}" }
+    sequence(:body) { |n| "<p>Comment #{n}</p>" }
+    sequence(:body_preview) { |n| "<p>Comment #{n}</p>" }
 
     association :post
     association :user
 
-    transient do
-      mention_count 5
+    trait :draft do
+      aasm_state :draft
+      markdown nil
+      body nil
+      markdown_preview "Comment content"
+      body_preview "Comment content"
+    end
+
+    trait :published do
+      aasm_state :published
+      markdown "Comment content"
+      body "Comment content"
+      markdown_preview "Comment content"
+      body_preview "Comment content"
+    end
+
+    trait :edited do
+      aasm_state :edited
+      markdown "Comment content"
+      body "Comment content"
+      markdown_preview "Comment content"
+      body_preview "Comment content"
     end
 
     trait :with_user_mentions do
+      transient do
+        mention_count 5
+      end
+
       after :create do |comment, evaluator|
         create_list(:comment_user_mention, evaluator.mention_count, comment: comment)
       end

--- a/spec/factories/post_factory.rb
+++ b/spec/factories/post_factory.rb
@@ -24,22 +24,43 @@ FactoryGirl.define do
 
   factory :post do
     sequence(:title) { |n| "Post #{n}" }
-    sequence(:markdown) { |n| "Post markdown #{n}" }
+    sequence(:markdown) { |n| "Post content #{n}" }
+    sequence(:markdown_preview) { |n| "Post content #{n}" }
+    sequence(:body) { |n| "<p>Post content #{n}</p>" }
+    sequence(:body_preview) { |n| "<p>Post content #{n}</p>" }
 
     association :user
     association :project
 
-    transient do
-      mention_count 5
+    trait :draft do
+      aasm_state :draft
+      markdown nil
+      body nil
+      markdown_preview "Post content"
+      body_preview "Post content"
     end
 
     trait :published do
-      after :create do |post, evaluator|
-        post.publish!
-      end
+      aasm_state :published
+      markdown "Post content"
+      body "Post content"
+      markdown_preview "Post content"
+      body_preview "Post content"
+    end
+
+    trait :edited do
+      aasm_state :edited
+      markdown "Post content"
+      body "Post content"
+      markdown_preview "Post content"
+      body_preview "Post content"
     end
 
     trait :with_user_mentions do
+      transient do
+        mention_count 5
+      end
+
       after :create do |post, evaluator|
         create_list(:post_user_mention, evaluator.mention_count, post: post)
       end

--- a/spec/lib/code_corps/scenario/generate_notifications_for_post_user_mentions_spec.rb
+++ b/spec/lib/code_corps/scenario/generate_notifications_for_post_user_mentions_spec.rb
@@ -53,6 +53,6 @@ module CodeCorps
           end
         end
       end
-    end 
+    end
   end
 end

--- a/spec/lib/code_corps/scenario/generate_user_mentions_for_comment_spec.rb
+++ b/spec/lib/code_corps/scenario/generate_user_mentions_for_comment_spec.rb
@@ -13,7 +13,8 @@ module CodeCorps
         end
 
         it "creates user mentions" do
-          comment = create(:comment, markdown: "Mentioning @joshsmith")
+          comment = build(:comment, markdown_preview: "Mentioning @joshsmith")
+          comment.update
 
           GenerateUserMentionsForComment.new(comment).call
 
@@ -26,6 +27,6 @@ module CodeCorps
           expect(post.comment_user_mentions).to include mention
         end
       end
-    end 
+    end
   end
 end

--- a/spec/lib/code_corps/scenario/generate_user_mentions_for_post_spec.rb
+++ b/spec/lib/code_corps/scenario/generate_user_mentions_for_post_spec.rb
@@ -13,7 +13,8 @@ module CodeCorps
         end
 
         it "creates user mentions" do
-          post = create(:post, markdown: "Mentioning @joshsmith")
+          post = build(:post, markdown_preview: "Mentioning @joshsmith")
+          post.update
 
           GenerateUserMentionsForPost.new(post).call
 
@@ -23,6 +24,6 @@ module CodeCorps
           expect(mention.username).to eq mentioned_username
         end
       end
-    end 
+    end
   end
 end

--- a/spec/requests/api/comments_spec.rb
+++ b/spec/requests/api/comments_spec.rb
@@ -23,7 +23,8 @@ describe "Comments API" do
     context "when unauthenticated" do
       before do
         @post = create(:post, id: 2)
-        create_list(:comment, 3, post: @post)
+        create_list(:comment, 3, :published, post: @post)
+        create_list(:comment, 2, :draft, post: @post)
 
         get "#{host}/posts/#{@post.id}/comments"
       end
@@ -32,8 +33,8 @@ describe "Comments API" do
         expect(last_response.status).to eq 200
       end
 
-      it "responds with the comments, serialized with CommentSerializer" do
-        collection = @post.comments
+      it "responds with active comments, serialized with CommentSerializer" do
+        collection = @post.comments.active
         expect(json).to(
           serialize_collection(collection).
           with(CommentSerializer)
@@ -44,7 +45,7 @@ describe "Comments API" do
 
   context "POST /comments" do
     context "when unauthenticated" do
-      it "should return a 401 with a proper error" do
+      it "responds with a proper 401" do
         post "#{host}/comments", data: { type: "comments" }
         expect(last_response.status).to eq 401
         expect(json).to be_a_valid_json_api_error.with_id "NOT_AUTHORIZED"
@@ -52,306 +53,340 @@ describe "Comments API" do
     end
 
     context "when authenticated" do
+      let(:user) { create :user, password: "password" }
+      let(:users_post) { create :post, user: user }
+      let(:token) { authenticate email: user.email, password: "password" }
+
+      let(:mentioned_1) { create(:user) }
+      let(:mentioned_2) { create(:user) }
+
+      def make_request(params)
+        authenticated_post "/comments", params, token
+      end
+
+      def make_request_with_sidekiq_inline(params)
+        Sidekiq::Testing.inline! { make_request params }
+      end
+
+      let(:params) do
+        {
+          data: {
+            type: "comments",
+            attributes: {
+              markdown_preview: "@#{mentioned_1.username} @#{mentioned_2.username}"
+            },
+            relationships: {
+              post: { data: { id: users_post.id, type: "posts" } }
+            }
+          }
+        }
+      end
+
       before do
-        @user = create(:user, email: "test_user@mail.com", password: "password")
-        @token = authenticate(email: "test_user@mail.com", password: "password")
-        @post = create(:post)
+        ActionMailer::Base.deliveries.clear
       end
 
-      def make_request
-        authenticated_post "/comments", @params, @token
-      end
-
-      def make_request_with_sidekiq_inline
-        Sidekiq::Testing.inline! { make_request }
-      end
-
-      it "requires a post to be specified" do
-        @params = { data: {
-          type: "comments", attributes: { markdown: "Comment body" }
-        } }
-        make_request
-
-        expect(last_response.status).to eq 422
-        expect(json).to be_a_valid_json_api_validation_error
-      end
-
-      it "requires a body to be specified" do
-        @params = { data: {
-          type: "comments",
-          attributes: {},
-          relationships: { post: { data: { id: @post.id, type: "posts" } } }
-        } }
-        make_request
-
-        expect(last_response.status).to eq 422
-        expect(json).to be_a_valid_json_api_validation_error
-      end
-
-      context "when it succeeds" do
-        context "as a draft" do
-          before do
-            @mention_1 = create(:user)
-            @mention_2 = create(:user)
-
-            @params = { data: {
-              type: "comments",
-              attributes: {
-                markdown: "@#{@mention_1.username} @#{@mention_2.username}"
-              },
-              relationships: {
-                post: { data: { id: @post.id, type: "posts" } }
-              }
-            } }
-          end
-
-          it "creates a comment" do
-            make_request
-            comment = Comment.last
-
-            expect(comment.markdown)
-              .to eq "@#{@mention_1.username} @#{@mention_2.username}"
-            expect(comment.body)
-              .to eq "<p>@#{@mention_1.username} @#{@mention_2.username}</p>"
-
-            expect(comment.user_id).to eq @user.id
-            expect(comment.post_id).to eq @post.id
-          end
-
-          it "returns the created comment, serialized with CommentSerializer" do
-            make_request
-
-            expect(json).to serialize_object(Comment.last)
-              .with(CommentSerializer)
-          end
-
-          it "sets user to current user" do
-            make_request
-            comment_relationships = json.data.relationships
-            expect(comment_relationships.user).not_to be_nil
-            expect(comment_relationships.user.data.id).to eq @user.id.to_s
-          end
-
-          it "creates mentions" do
-            expect { make_request_with_sidekiq_inline }
-              .to change { CommentUserMention.count }.by 2
-          end
-
-          it "does not create notifications for each mentioned user" do
-            expect { make_request_with_sidekiq_inline }
-              .to_not change { Notification.sent.count }
-          end
-
-          it "does not send mails for each mentioned user" do
-            expect { make_request_with_sidekiq_inline }
-              .to_not change { ActionMailer::Base.deliveries.count }
-          end
+      context "when requesting a preview" do
+        before do
+          params[:data][:attributes][:preview] = true
         end
 
-        context "when publishing" do
+        it "creates a draft" do
+          make_request_with_sidekiq_inline params
+
+          comment = Comment.last
+
+          # response is correct
+          expect(last_response.status).to eq 200
+          expect(json).to serialize_object(comment).with(CommentSerializer)
+
+          # state is proper
+          expect(comment.draft?).to be true
+
+          # attributes are properly set
+          expect(comment.body).to be_nil
+          expect(comment.markdown).to be_nil
+          expect(comment.body_preview).to eq "<p>@#{mentioned_1.username} @#{mentioned_2.username}</p>"
+          expect(comment.markdown_preview).to eq "@#{mentioned_1.username} @#{mentioned_2.username}"
+
+          # relationships are properly set
+          expect(comment.user_id).to eq user.id
+          expect(comment.post_id).to eq users_post.id
+
+          # correct number of mentions was generated
+          expect(CommentUserMention.count).to eq 2
+
+          # no notifications were sent or created
+          expect(Notification.pending.count).to eq 0
+
+          # no mails were sent
+          expect(ActionMailer::Base.deliveries.count).to eq 0
+        end
+      end
+
+      context "when requesting an actual save" do
+        it "creates a published comment" do
+          make_request_with_sidekiq_inline params
+
+          comment = Comment.last
+
+          # response is correct
+          expect(json).to serialize_object(Comment.last).with(CommentSerializer)
+
+          # state is proper
+          expect(comment.published?).to be true
+
+          # attributes are properly set
+          expect(comment.body).to eq "<p>@#{mentioned_1.username} @#{mentioned_2.username}</p>"
+          expect(comment.markdown).to eq "@#{mentioned_1.username} @#{mentioned_2.username}"
+          expect(comment.body_preview).to eq "<p>@#{mentioned_1.username} @#{mentioned_2.username}</p>"
+          expect(comment.markdown_preview).to eq "@#{mentioned_1.username} @#{mentioned_2.username}"
+
+          # relationships are properly set
+          expect(comment.user_id).to eq user.id
+          expect(comment.post_id).to eq users_post.id
+
+          # a mention was generated for each mentioned user
+          expect(CommentUserMention.count).to eq 2
+
+          # a notification was sent for each generated mention
+          expect(Notification.sent.count).to eq 2
+
+          # an email was sent for each notification
+          expect(ActionMailer::Base.deliveries.count).to eq 2
+        end
+
+        context "when markdown_preview is an empty string" do
           before do
-            @mention_1 = create(:user)
-            @mention_2 = create(:user)
-
-            @params = { data: {
-              type: "comments",
-              attributes: {
-                markdown: "@#{@mention_1.username} @#{@mention_2.username}",
-                state: "published"
-              },
-              relationships: {
-                post: { data: { id: @post.id, type: "posts" } }
-              }
-            } }
+            params[:data][:attributes][:markdown_preview] = ""
           end
 
-          it "creates a comment" do
-            expect { make_request }.to change { Comment.count }.by 1
-            comment = Comment.last
-            expect(comment.markdown)
-              .to eq "@#{@mention_1.username} @#{@mention_2.username}"
-            expect(comment.body)
-              .to eq "<p>@#{@mention_1.username} @#{@mention_2.username}</p>"
-
-            expect(comment.post).to eq @post
-            expect(comment.user).to eq @user
-          end
-
-          it "returns the created comment, serialized with CommentSerializer" do
-            make_request
-
-            expect(json).to serialize_object(Comment.last)
-              .with(CommentSerializer)
-          end
-
-          it "creates mentions" do
-            expect { make_request_with_sidekiq_inline }
-              .to change { CommentUserMention.count }.by 2
-          end
-
-          it "creates notifications for each mentioned user" do
-            expect { make_request_with_sidekiq_inline }
-              .to change { Notification.sent.count }.by 2
-          end
-
-          it "sends mails for each mentioned user" do
-            expect { make_request_with_sidekiq_inline }
-              .to change { ActionMailer::Base.deliveries.count }.by 2
+          it "responds with a validation error" do
+            make_request_with_sidekiq_inline params
+            expect(last_response.status).to eq 422
           end
         end
       end
+
+      context "when the attributes are invalid" do
+        let(:invalid_attributes) do
+          {
+            data: {
+              attributes: {
+                title: "", markdown_preview: ""
+              },
+              relationships: {
+                post: { data: { id: users_post.id, type: "posts" } }
+              }
+            }
+          }
+        end
+
+        it "responds with a 422 validation error" do
+          make_request invalid_attributes
+          expect(last_response.status).to eq 422
+          expect(json).to be_a_valid_json_api_validation_error
+        end
+      end
+
+
     end
   end
 
   context "PATCH /comments/:id" do
     context "when unauthenticated" do
-      it "should return a 401 with a proper error" do
-        patch "#{host}/comments/1", data: { type: "comments" }
+      it "responds with a proper 401" do
+        patch "#{host}/comments/1"
         expect(last_response.status).to eq 401
         expect(json).to be_a_valid_json_api_error.with_id "NOT_AUTHORIZED"
       end
     end
 
     context "when authenticated" do
-      before do
-        @user = create(:user,
-          id: 1, email: "test_user@mail.com", password: "password")
-        @post = create(:post, id: 2)
-        @token = authenticate(email: "test_user@mail.com", password: "password")
+      let(:user) { create :user, password: "password" }
+      let(:token) { authenticate email: user.email, password: "password" }
+      let(:post) { create :post, user: user }
+      let(:mentioned_1) { create(:user) }
+      let(:mentioned_2) { create(:user) }
+
+      def make_request(params)
+        authenticated_patch "/comments/#{comment.id}", params, token
       end
 
-      context "when the comment doesn't exist" do
+      def make_request_with_sidekiq_inline(params)
+        Sidekiq::Testing.inline! { make_request params }
+      end
+
+      let(:params) do
+        {
+          data: {
+            id: comment.id,
+            type: "comments",
+            attributes: {
+              title: "Edited title",
+              markdown_preview: "@#{mentioned_1.username} @#{mentioned_2.username}"
+            }
+          }
+        }
+      end
+
+      context "when comment does not exist" do
         it "responds with a 404" do
-          authenticated_patch "/comments/1",
-            { data: { type: "comments" } }, @token
+          authenticated_patch "/comments/bad_id", { data: { type: "comments" } }, token
 
           expect(last_response.status).to eq 404
           expect(json).to be_a_valid_json_api_error.with_id "RECORD_NOT_FOUND"
         end
       end
 
-      context "when the comment does exist" do
+      context "when comment is a draft" do
+        let(:comment) { create :comment, :draft, post: post, user: user }
+
         before do
-          @comment = create(:comment, post: @post, user: @user)
+          ActionMailer::Base.deliveries.clear
         end
 
-        context "when the attributes are valid" do
-          context "when updating a draft" do
-            before do
-              valid_attributes = {
-                data: {
-                  attributes: {
-                    markdown: "Edited body"
-                  },
-                  relationships: {
-                    post: { data: { id: @post.id, type: "posts" } }
-                  }
-                }
-              }
-              authenticated_patch "/comments/#{@comment.id}",
-                valid_attributes, @token
-            end
-
-            it "responds with a 200" do
-              expect(last_response.status).to eq 200
-            end
-
-            it "responds with the comment, serialized with CommentSerializer" do
-              expect(json).to serialize_object(@comment.reload)
-                .with(CommentSerializer)
-            end
-
-            it "updates the comment" do
-              @comment.reload
-
-              expect(@comment.markdown).to eq "Edited body"
-              expect(@comment.body).to eq "<p>Edited body</p>"
-            end
+        context "when requesting a preview" do
+          before do
+            params[:data][:attributes][:preview] = true
           end
 
-          context "when publishing a comment" do
-            before do
-              valid_attributes = {
-                data: {
-                  attributes: {
-                    markdown: "Edited body", state: "published"
-                  },
-                  relationships: {
-                    post: { data: { id: @post.id, type: "posts" } }
-                  }
-                }
-              }
-              authenticated_patch "/comments/#{@comment.id}",
-                valid_attributes, @token
-            end
+          it "updates the draft" do
+            make_request_with_sidekiq_inline params
 
-            it "updates the comment" do
-              @comment.reload
+            # response is correct
+            expect(last_response.status).to eq 200
+            expect(json).to serialize_object(comment.reload).with(CommentSerializer)
 
-              expect(@comment).to be_published
-            end
+            # state is proper
+            expect(comment.draft?).to be true
+
+            # attributes are properly set
+            expect(comment.body).to be_nil
+            expect(comment.markdown).to be_nil
+            expect(comment.body_preview).to eq "<p>@#{mentioned_1.username} @#{mentioned_2.username}</p>"
+            expect(comment.markdown_preview).to eq "@#{mentioned_1.username} @#{mentioned_2.username}"
+
+            # relationships are properly set
+            expect(comment.user_id).to eq user.id
+            expect(comment.post_id).to eq post.id
+
+            # correct number of mentions was generated
+            expect(CommentUserMention.count).to eq 2
+
+            # no notifications were sent or created
+            expect(Notification.pending.count).to eq 0
+
+            # no mails were sent
+            expect(ActionMailer::Base.deliveries.count).to eq 0
           end
+        end
 
-          context "when editing a published comment" do
-            before do
-              @comment.publish!
+        context "when requesting an actual save" do
+          it "updates and publishes comment" do
+            params[:data][:attributes][:publish] = true
+            make_request_with_sidekiq_inline params
 
-              valid_attributes = {
-                data: {
-                  attributes: {
-                    markdown: "Edited body"
-                  },
-                  relationships: {
-                    post: { data: { id: @post.id, type: "posts" } }
-                  }
-                }
-              }
-              authenticated_patch "/comments/#{@comment.id}",
-                valid_attributes, @token
-            end
+            # response is correct
+            expect(last_response.status).to eq 200
+            expect(json).to serialize_object(comment.reload).with(CommentSerializer)
 
-            it "updates the comment" do
-              @comment.reload
+            # state is proper
+            expect(comment.published?).to be true
 
-              expect(@comment).to be_edited
-            end
+            # attributes are properly set
+            expect(comment.body).to eq "<p>@#{mentioned_1.username} @#{mentioned_2.username}</p>"
+            expect(comment.markdown).to eq "@#{mentioned_1.username} @#{mentioned_2.username}"
+            expect(comment.body_preview).to eq "<p>@#{mentioned_1.username} @#{mentioned_2.username}</p>"
+            expect(comment.markdown_preview).to eq "@#{mentioned_1.username} @#{mentioned_2.username}"
+
+            # relationships are properly set
+            expect(comment.user_id).to eq user.id
+            expect(comment.post_id).to eq post.id
+
+            # a mention was generated for each mentioned user
+            expect(CommentUserMention.count).to eq 2
+
+            # a notification was sent for each generated mention
+            expect(Notification.sent.count).to eq 2
+
+            # an email was sent for each notification
+            expect(ActionMailer::Base.deliveries.count).to eq 2
           end
         end
 
         context "when the attributes are invalid" do
-          before do
-            invalid_attributes = {
+          let(:invalid_attributes) do
+            {
               data: {
                 attributes: {
-                  markdown: ""
-                },
-                relationships: {
-                  post: { data: { id: @post.id, type: "posts" } }
+                  markdown_preview: nil
                 }
               }
             }
-            authenticated_patch "/comments/#{@comment.id}",
-              invalid_attributes, @token
           end
 
           it "responds with a 422 validation error" do
+            make_request invalid_attributes
             expect(last_response.status).to eq 422
             expect(json).to be_a_valid_json_api_validation_error
           end
         end
       end
 
-      context "when updating another user's comment" do
-        before do
-          @comment = create(:comment, post: @post)
+      context "when comment is published" do
+        let(:comment) { create :comment, :published, post: post, user: user }
+
+        context "when requesting a preview" do
+          before do
+            params[:data][:attributes][:preview] = true
+          end
+
+          it "updates the published comment" do
+            make_request_with_sidekiq_inline params
+
+            # response is correct
+            expect(last_response.status).to eq 200
+            expect(json).to serialize_object(comment.reload).with(CommentSerializer)
+
+            # state is proper
+            expect(comment.published?).to be true
+          end
         end
 
-        it "responds with a 401 ACCESS_DENIED" do
-          authenticated_patch "/comments/#{@comment.id}",
-            { data: { type: "comments" } }, @token
+        context "when requesting an actual save" do
+          it "updates and post and sets it to edited state" do
+            params[:data][:attributes][:publish] = true
+            make_request_with_sidekiq_inline params
 
-          expect(last_response.status).to eq 401
-          expect(json).to be_a_valid_json_api_error.with_id "ACCESS_DENIED"
+            # response is correct
+            expect(last_response.status).to eq 200
+            expect(json).to serialize_object(comment.reload).with(CommentSerializer)
+
+            # state is proper
+            expect(comment.edited?).to be true
+          end
+        end
+      end
+
+      context "when comment exists and markdown_preview param is an empty string" do
+        let(:comment) { create :comment, :draft, post: post, user: user }
+
+        before do
+          params[:data][:attributes][:preview] = true
+          params[:data][:attributes][:markdown_preview] = ""
+        end
+
+        it "overwrites the body_preview with new markdown data" do
+          make_request_with_sidekiq_inline params
+          expect(last_response.status).to eq 200
+
+          comment.reload
+          expect(comment.markdown_preview).to eq ""
+          expect(comment.body_preview).to eq ""
+
+          expect(json.data.attributes.markdown_preview).to eq ""
+          expect(json.data.attributes.body_preview).to eq ""
         end
       end
     end

--- a/spec/requests/api/posts_spec.rb
+++ b/spec/requests/api/posts_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 describe "Posts API" do
-
   context "GET /projects/:id/posts" do
     context "when the project doesn't exist" do
       it "responds with a 404" do
@@ -15,13 +14,14 @@ describe "Posts API" do
       before do
         @project = create(:project, organization: create(:organization))
         create_list(:post, 3, :published, project: @project, post_type: "issue")
-        create_list(:post, 10, :published, project: @project, post_type: "task")
+        create_list(:post, 7, :published, project: @project, post_type: "task")
+        create_list(:post, 3, :edited, project: @project, post_type: "idea")
       end
 
-      it "returns only published posts" do
-        create_list(:post, 5, project: @project)
+      it "returns active posts (published and edited)" do
+        create_list(:post, 5, :draft, project: @project)
         get "#{host}/projects/#{@project.id}/posts"
-        collection = Post.published.page(1).per(10)
+        collection = Post.active.page(1).per(10)
         expect(json).to(
           serialize_collection(collection).
             with(PostSerializer).
@@ -148,175 +148,145 @@ describe "Posts API" do
   end
 
   context "POST /posts" do
-
     context "when unauthenticated" do
-      it "should return a 401 with a proper error" do
-        post "#{host}/posts", { data: { type: "posts" } }
+      it "responds with a proper 401" do
+        post "#{host}/posts", data: { type: "posts" }
         expect(last_response.status).to eq 401
         expect(json).to be_a_valid_json_api_error.with_id "NOT_AUTHORIZED"
       end
     end
 
     context "when authenticated" do
-      before do
-        @user = create(:user, email: "test_user@mail.com", password: "password")
-        @organization = create(:organization)
-        @project = create(:project, organization: @organization)
-        create(:organization_membership, member: @user, organization: @organization, role: "contributor")
-        @token = authenticate(email: "test_user@mail.com", password: "password")
-      end
+      let(:user) { create :user, password: "password" }
+      let(:organization) { create :organization }
+      let(:project) { create :project, organization: organization }
+      let(:token) { authenticate email: user.email, password: "password" }
 
-      it "requires a 'project' to be specified" do
-        params = { data: { type: "posts", attributes: { title: "Post title", post_type: "issue" } } }
-        authenticated_post "/posts", params, @token
+      let(:mentioned_1) { create(:user) }
+      let(:mentioned_2) { create(:user) }
 
-        expect(last_response.status).to eq 422
-        expect(json).to be_a_valid_json_api_validation_error
-      end
-
-      it "requires a 'title' to be specified" do
-        params = { data: { type: "posts",
-          attributes: { post_type: "issue" },
-          relationships: { project: { data: { id: @project.id } } }
-        } }
-        authenticated_post "/posts", params, @token
-
-        expect(last_response.status).to eq 422
-        expect(json).to be_a_valid_json_api_validation_error
-      end
-
-      it "requires a 'body' to be specified" do
-        params = { data: { type: "posts",
-          attributes: { title: "Post title", post_type: "issue" },
-          relationships: { project: { data: { id: @project.id } } }
-        } }
-        authenticated_post "/posts", params, @token
-
-        expect(last_response.status).to eq 422
-        expect(json).to be_a_valid_json_api_validation_error
-      end
-
-      it "does not accept a 'number' to be set directly" do
-        params = { data: { type: "posts",
-          attributes: { title: "Post title", markdown: "Post body", number: 3 },
-          relationships: { project: { data: { id: @project.id } } }
-        } }
-        authenticated_post "/posts", params, @token
-
-        expect(last_response.status).to eq 200
-
-        expect(json.data.attributes.number).to eq nil
-      end
-
-      it "does not require a 'post_type' to be specified" do
-        params = { data: { type: "posts",
-          attributes: { title: "Post title", markdown: "Post body" },
-          relationships: { project: { data: { id: @project.id } } }
-        } }
-        authenticated_post "/posts", params, @token
-
-        expect(last_response.status).to eq 200
-      end
-
-      it "ignores the 'status' parameter" do
-        params = { data: { type: "posts",
-          attributes: { title: "Post title", post_type: "issue", status: "closed", markdown: "Post body" },
-          relationships: { project: { data: { id: @project.id } } }
-        } }
-        authenticated_post "/posts", params, @token
-
-        expect(last_response.status).to eq 200
-        expect(Post.last.open?).to be true
-      end
-
-      context "when it succeeds" do
-        before do
-          create(:project, id: 1)
-
-          @mentioned_1 = create(:user)
-          @mentioned_2 = create(:user)
-
-          @params = { data: {
+      let(:params) do
+        {
+          data: {
             type: "posts",
             attributes: {
               title: "Post title",
-              markdown: "@#{@mentioned_1.username} @#{@mentioned_2.username}",
+              markdown_preview: "@#{mentioned_1.username} @#{mentioned_2.username}",
               post_type: "issue"
             },
             relationships: {
-              project: { data: { id: @project.id, type: "projects" } }
+              project: { data: { id: project.id, type: "projects" } }
             }
-          } }
-        end
+          }
+        }
+      end
 
-        def make_request
-           authenticated_post "/posts", @params, @token
-        end
+      before do
+        create(
+          :organization_membership,
+          member: user, organization: organization, role: "contributor")
 
-        def make_request_with_sidekiq_inline
-          Sidekiq::Testing::inline! { make_request }
-        end
+        ActionMailer::Base.deliveries.clear
+      end
 
-        it "creates a draft post" do
-          expect{ make_request }.to change{ Post.draft.count }.by 1
+      def make_request(params)
+        authenticated_post "/posts", params, token
+      end
+
+      def make_request_with_sidekiq_inline(params)
+        Sidekiq::Testing.inline! { make_request params }
+      end
+
+      context "when requesting a preview" do
+        it "creates a draft" do
+          params[:data][:attributes][:preview] = true
+          make_request_with_sidekiq_inline params
 
           post = Post.last
+
+          # response is correct
+          expect(last_response.status).to eq 200
+          expect(json).to serialize_object(post).with(PostSerializer)
+
+          # state is proper
+          expect(post.draft?).to be true
+
+          # attributes are properly set
           expect(post.title).to eq "Post title"
-          expect(post.body).to eq "<p>@#{@mentioned_1.username} @#{@mentioned_2.username}</p>"
           expect(post.issue?).to be true
+          expect(post.body).to be_nil
+          expect(post.markdown).to be_nil
+          expect(post.body_preview).to eq "<p>@#{mentioned_1.username} @#{mentioned_2.username}</p>"
+          expect(post.markdown_preview).to eq "@#{mentioned_1.username} @#{mentioned_2.username}"
+
+          # relationships are properly set
+          expect(post.user_id).to eq user.id
+          expect(post.project_id).to eq project.id
+
+          # correct number of mentions was generated
+          expect(PostUserMention.count).to eq 2
+
+          # no notifications were sent or created
+          expect(Notification.pending.count).to eq 0
+
+          # no mails were sent
+          expect(ActionMailer::Base.deliveries.count).to eq 0
+        end
+      end
+
+      context "when requesting an actual save" do
+        it "creates a published post" do
+          make_request_with_sidekiq_inline params
+
+          post = Post.last
+
+          # response is correct
+          expect(json).to serialize_object(post).with(PostSerializer)
+
+          # state is proper
+          expect(post.published?).to be true
+
+          # attributes are properly set
+          expect(post.title).to eq "Post title"
+          expect(post.issue?).to be true
+          expect(post.body).to eq "<p>@#{mentioned_1.username} @#{mentioned_2.username}</p>"
+          expect(post.markdown).to eq "@#{mentioned_1.username} @#{mentioned_2.username}"
+          expect(post.body_preview).to eq "<p>@#{mentioned_1.username} @#{mentioned_2.username}</p>"
+          expect(post.markdown_preview).to eq "@#{mentioned_1.username} @#{mentioned_2.username}"
+
+          # relationships are properly set
+          expect(post.user_id).to eq user.id
+          expect(post.project_id).to eq project.id
+
+          # a mention was generated for each mentioned user
+          expect(PostUserMention.count).to eq 2
+
+          # a notification was sent for each generated mention
+          expect(Notification.sent.count).to eq 2
+
+          # an email was sent for each notification
+          expect(ActionMailer::Base.deliveries.count).to eq 2
+        end
+      end
+
+      context "when the attributes are invalid" do
+        let(:invalid_attributes) do
+          {
+            data: {
+              attributes: {
+                title: nil, markdown_preview: nil
+              },
+              relationships: {
+                project: { data: { id: project.id, type: "projects" } }
+              }
+            }
+          }
         end
 
-        it "returns the created post, serialized with PostSerializer" do
-          make_request
-
-          expect(json).to serialize_object(Post.last).with(PostSerializer)
-        end
-
-        it "sets user to current user" do
-          make_request
-
-          expect(Post.last.user_id).to eq @user.id
-        end
-
-        it "sets status to 'open'" do
-          make_request
-
-          expect(Post.last.open?).to be true
-        end
-
-        it "creates mentions" do
-          expect{ make_request }.to change { PostUserMention.count }.by 2
-        end
-
-        it "doesn't create noficiations" do
-          expect{ make_request_with_sidekiq_inline }.not_to change{ Notification.pending.count }
-          expect{ make_request_with_sidekiq_inline }.not_to change{ Notification.sent.count }
-        end
-
-        it "doesn't send emails" do
-          expect{ make_request_with_sidekiq_inline }.not_to change{ ActionMailer::Base.deliveries.count }
-        end
-
-        context "when type is set to 'published'" do
-          before do
-            @params[:data][:attributes][:state] = "published"
-          end
-
-          it "creates a published post" do
-            expect{ make_request }.to change{ Post.published.count }.by 1
-          end
-
-          it "creates mentions" do
-            expect{ make_request_with_sidekiq_inline }.to change { PostUserMention.count }.by 2
-          end
-
-          it "creates notifications for each mentioned user" do
-            expect{ make_request_with_sidekiq_inline }.to change{ Notification.sent.count }.by 2
-          end
-
-          it "sends mails for each mentioned user" do
-            expect{ make_request_with_sidekiq_inline }.to change{ ActionMailer::Base.deliveries.count }.by 2
-          end
+        it "responds with a 422 validation error" do
+          authenticated_post "/posts", invalid_attributes, token
+          expect(last_response.status).to eq 422
+          expect(json).to be_a_valid_json_api_validation_error
         end
       end
     end
@@ -324,131 +294,214 @@ describe "Posts API" do
 
   context "PATCH /posts/:id" do
     context "when unauthenticated" do
-      it "should return a 401 with a proper error" do
-        patch "#{host}/posts/1", { data: { type: "posts" } }
+      it "responds with a proper 401" do
+        patch "#{host}/posts/1"
         expect(last_response.status).to eq 401
         expect(json).to be_a_valid_json_api_error.with_id "NOT_AUTHORIZED"
       end
     end
 
     context "when authenticated" do
-      before do
-        @user = create(:user, email: "test_user@mail.com", password: "password")
-        @organization = create(:organization)
-        @project = create(:project, organization: @organization)
-        create(:organization_membership, member: @user, organization: @organization, role: "contributor")
-        @token = authenticate(email: "test_user@mail.com", password: "password")
+      let(:user) { create :user, password: "password" }
+      let(:token) { authenticate email: user.email, password: "password" }
+      let(:organization) { create :organization }
+      let(:project) { create :project, organization: organization }
+      let(:mentioned_1) { create(:user) }
+      let(:mentioned_2) { create(:user) }
+
+      def make_request(params)
+        authenticated_patch "/posts/#{post.id}", params, token
       end
 
-      context "when the post doesn't exist" do
+      def make_request_with_sidekiq_inline(params)
+        Sidekiq::Testing.inline! { make_request params }
+      end
+
+      let(:params) do
+        {
+          data: {
+            id: post.id,
+            type: "posts",
+            attributes: {
+              title: "Edited title",
+              markdown_preview: "@#{mentioned_1.username} @#{mentioned_2.username}"
+            },
+            relationships: {
+              project: { data: { id: project.id, type: "projects" } }
+            }
+          }
+        }
+      end
+
+      before do
+        create(
+          :organization_membership,
+          member: user, organization: organization, role: "contributor")
+      end
+
+      context "when post does not exist" do
         it "responds with a 404" do
-          authenticated_patch "/posts/1", { data: { type: "posts" } }, @token
+          authenticated_patch "/posts/bad_id", { data: { type: "posts" } }, token
 
           expect(last_response.status).to eq 404
           expect(json).to be_a_valid_json_api_error.with_id "RECORD_NOT_FOUND"
         end
       end
 
-      context "when the post does exist" do
+      context "when post is a draft" do
+        let(:post) { create :post, :draft, project: project, user: user, post_type: "issue" }
+
         before do
-          @post = create(:post, project: @project, user: @user)
-          @mentioned_1 = create(:user)
-          @mentioned_2 = create(:user)
-          @params = { data: {
-            attributes: { title: "Edited title", markdown: "@#{@mentioned_1.username} @#{@mentioned_2.username}" },
-            relationships: { project: { data: { id: @project.id, type: "projects" } } }
-          } }
+          ActionMailer::Base.deliveries.clear
         end
 
-        def make_request
-          authenticated_patch "/posts/#{@post.id}", @params, @token
-        end
-
-        def make_request_with_sidekiq_inline
-          Sidekiq::Testing::inline! { make_request }
-        end
-
-        context "when the attributes are valid" do
-          context "when updating a draft" do
-            it "responds with a 200" do
-              make_request
-              expect(last_response.status).to eq 200
-            end
-
-            it "responds with the post, serialized with PostSerializer" do
-              make_request
-              expect(json).to serialize_object(@post.reload).with(PostSerializer)
-            end
-
-            it "updates the post" do
-              make_request
-
-              @post.reload
-
-              expect(@post.title).to eq "Edited title"
-              expect(@post.markdown).to eq "@#{@mentioned_1.username} @#{@mentioned_2.username}"
-              expect(@post.body).to eq "<p>@#{@mentioned_1.username} @#{@mentioned_2.username}</p>"
-            end
-
-            it "creates mentions" do
-              expect{ make_request }.to change { PostUserMention.count }.by 2
-            end
-
-            it "doesn't create noficiations" do
-              expect{ make_request_with_sidekiq_inline }.not_to change{ Notification.pending.count }
-              expect{ make_request_with_sidekiq_inline }.not_to change{ Notification.sent.count }
-            end
-
-            it "doesn't send emails" do
-              expect{ make_request_with_sidekiq_inline }.not_to change{ ActionMailer::Base.deliveries.count }
-            end
+        context "when requesting a preview" do
+          before do
+            params[:data][:attributes][:preview] = true
           end
 
-          context "when editing a published post" do
-            before do
-              @post.publish!
-            end
+          it "updates the draft" do
+            make_request_with_sidekiq_inline params
 
-            it "updates the post" do
-              make_request
+            # response is correct
+            expect(last_response.status).to eq 200
+            expect(json).to serialize_object(post.reload).with(PostSerializer)
 
-              @post.reload
-              expect(@post).to be_edited
-            end
+            # state is proper
+            expect(post.draft?).to be true
 
-            it "creates mentions" do
-              expect{ make_request_with_sidekiq_inline }.to change { PostUserMention.count }.by 2
-            end
+            # attributes are properly set
+            expect(post.title).to eq "Edited title"
+            expect(post.issue?).to be true
+            expect(post.body).to be_nil
+            expect(post.markdown).to be_nil
+            expect(post.body_preview).to eq "<p>@#{mentioned_1.username} @#{mentioned_2.username}</p>"
+            expect(post.markdown_preview).to eq "@#{mentioned_1.username} @#{mentioned_2.username}"
 
-            it "creates notifications for each mentioned user" do
-              expect{ make_request_with_sidekiq_inline }.to change{ Notification.sent.count }.by 2
-            end
+            # relationships are properly set
+            expect(post.user_id).to eq user.id
+            expect(post.project_id).to eq project.id
 
-            it "sends mails for each mentioned user" do
-              expect{ make_request_with_sidekiq_inline }.to change{ ActionMailer::Base.deliveries.count }.by 2
-            end
+            # correct number of mentions was generated
+            expect(PostUserMention.count).to eq 2
+
+            # no notifications were sent or created
+            expect(Notification.pending.count).to eq 0
+
+            # no mails were sent
+            expect(ActionMailer::Base.deliveries.count).to eq 0
+          end
+        end
+
+        context "when requesting an actual save" do
+          it "updates and publishes post" do
+            make_request_with_sidekiq_inline params
+
+            # response is correct
+            expect(last_response.status).to eq 200
+            expect(json).to serialize_object(post.reload).with(PostSerializer)
+
+            # state is proper
+            expect(post.published?).to be true
+
+            # attributes are properly set
+            expect(post.title).to eq "Edited title"
+            expect(post.issue?).to be true
+            expect(post.body).to eq "<p>@#{mentioned_1.username} @#{mentioned_2.username}</p>"
+            expect(post.markdown).to eq "@#{mentioned_1.username} @#{mentioned_2.username}"
+            expect(post.body_preview).to eq "<p>@#{mentioned_1.username} @#{mentioned_2.username}</p>"
+            expect(post.markdown_preview).to eq "@#{mentioned_1.username} @#{mentioned_2.username}"
+
+            # relationships are properly set
+            expect(post.user_id).to eq user.id
+            expect(post.project_id).to eq project.id
+
+            # a mention was generated for each mentioned user
+            expect(PostUserMention.count).to eq 2
+
+            # a notification was sent for each generated mention
+            expect(Notification.sent.count).to eq 2
+
+            # an email was sent for each notification
+            expect(ActionMailer::Base.deliveries.count).to eq 2
           end
         end
 
         context "when the attributes are invalid" do
-          before do
-            invalid_attributes = {
+          let(:invalid_attributes) do
+            {
               data: {
                 attributes: {
-                  title: "", markdown: ""
+                  title: "", markdown_preview: ""
                 },
                 relationships: {
-                  project: { data: { id: @project.id, type: "projects" } }
+                  project: { data: { id: project.id, type: "projects" } }
                 }
               }
             }
-            authenticated_patch "/posts/#{@post.id}", invalid_attributes, @token
           end
 
           it "responds with a 422 validation error" do
+            authenticated_patch "/posts/#{post.id}", invalid_attributes, token
             expect(last_response.status).to eq 422
             expect(json).to be_a_valid_json_api_validation_error
           end
+        end
+      end
+
+      context "when post is published" do
+        let(:post) { create :post, :published, project: project, user: user, post_type: :issue }
+
+        context "when requesting a preview" do
+          before do
+            params[:data][:attributes][:preview] = true
+          end
+
+          it "updates the published post" do
+            make_request_with_sidekiq_inline params
+
+            # response is correct
+            expect(last_response.status).to eq 200
+            expect(json).to serialize_object(post.reload).with(PostSerializer)
+
+            # state is proper
+            expect(post.published?).to be true
+          end
+        end
+
+        context "when requesting an actual save" do
+          it "updates and post and sets it to edited state" do
+            params[:data][:attributes][:publish] = true
+            make_request_with_sidekiq_inline params
+
+            # response is correct
+            expect(last_response.status).to eq 200
+            expect(json).to serialize_object(post.reload).with(PostSerializer)
+
+            # state is proper
+            expect(post.edited?).to be true
+          end
+        end
+      end
+
+      context "when post exists and markdown_preview param is an empty string" do
+        let(:post) { create :post, :draft, project: project, user: user, post_type: "issue" }
+
+        before do
+          params[:data][:attributes][:preview] = true
+          params[:data][:attributes][:markdown_preview] = ""
+        end
+
+        it "overwrites the body_preview with new markdown data" do
+          make_request_with_sidekiq_inline params
+          expect(last_response.status).to eq 200
+
+          post.reload
+          expect(post.markdown_preview).to eq ""
+          expect(post.body_preview).to eq ""
+
+          expect(json.data.attributes.markdown_preview).to eq ""
+          expect(json.data.attributes.body_preview).to eq ""
         end
       end
     end

--- a/spec/serializers/comment_serializer_spec.rb
+++ b/spec/serializers/comment_serializer_spec.rb
@@ -44,23 +44,34 @@ describe CommentSerializer, :type => :serializer do
         expect(subject["id"]).not_to be nil
       end
 
-      it "has a type set to 'projects'" do
+      it "has a type set to 'comments'" do
         expect(subject["type"]).to eq "comments"
       end
     end
 
     context "attributes" do
-
       subject do
         JSON.parse(serialization.to_json)["data"]["attributes"]
       end
 
       it "has a 'body'" do
+        expect(subject["body"]).not_to be_nil
         expect(subject["body"]).to eql resource.body
       end
 
       it "has 'markdown'" do
+        expect(subject["markdown"]).not_to be_nil
         expect(subject["markdown"]).to eql resource.markdown
+      end
+
+      it "has a 'body_preview'" do
+        expect(subject["body_preview"]).not_to be_nil
+        expect(subject["body_preview"]).to eql resource.body_preview
+      end
+
+      it "has 'markdown_preview'" do
+        expect(subject["markdown_preview"]).not_to be_nil
+        expect(subject["markdown_preview"]).to eql resource.markdown_preview
       end
 
       it "has a 'state'" do

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -22,15 +22,16 @@
 
 require "rails_helper"
 
-describe PostSerializer, :type => :serializer do
-
+describe PostSerializer, type: :serializer do
   # We only use before all here because we know the context does not change
   before :all do
-    @post = create(:post,
+    @post = create(
+      :post,
       title: "Post title",
       user: create(:user),
       project: create(:project),
-      number: 1)
+      number: 1
+    )
 
     @post.publish!
     @post.edit!
@@ -43,7 +44,6 @@ describe PostSerializer, :type => :serializer do
   end
 
   context "individual resource representation" do
-
     let(:resource) { @post }
 
     let(:serializer) { PostSerializer.new(resource) }
@@ -77,11 +77,23 @@ describe PostSerializer, :type => :serializer do
       end
 
       it "has a 'body'" do
+        expect(subject["body"]).not_to be_nil
         expect(subject["body"]).to eql resource.body
       end
 
       it "has 'markdown'" do
+        expect(subject["markdown"]).not_to be_nil
         expect(subject["markdown"]).to eql resource.markdown
+      end
+
+      it "has a 'body_preview'" do
+        expect(subject["body_preview"]).not_to be_nil
+        expect(subject["body_preview"]).to eql resource.body_preview
+      end
+
+      it "has 'markdown_preview'" do
+        expect(subject["markdown_preview"]).not_to be_nil
+        expect(subject["markdown_preview"]).to eql resource.markdown_preview
       end
 
       it "has a 'status'" do


### PR DESCRIPTION
Not done yet.

As expected, there are tweaks for things we've missed, now that I'm working on the ember part of it.
- `title` should not be required for posts, if the post is a draft, otherwise, preview wont work
- the `active` scope was broken on posts, and the post index action was returning only `published`, not `edited` posts
- the `active` scope was completely missing on comments
- the markdown rendering + preview/publish flow was clashing, so I attempted to simplify it a bit. this should make it faster, simpler to ready and a bit less bug prone, I hope, but it does mean we had to remove the rendering method from the before_validation hook and we're now running it manually.
