### PR TITLE
Fixes for organization profile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ group :development, :test do
   gem 'pry-rails'
   gem 'pry'
   gem 'pry-nav'
+  gem 'pry-remote'
   gem 'pry-stack_explorer'
 
   gem 'rspec-rails', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,9 @@ GEM
       pry (>= 0.9.10, < 0.11.0)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
+    pry-remote (0.1.8)
+      pry (~> 0.9)
+      slop (~> 3.0)
     pry-stack_explorer (0.4.9.2)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
@@ -341,6 +344,7 @@ DEPENDENCIES
   pry
   pry-nav
   pry-rails
+  pry-remote
   pry-stack_explorer
   pundit
   pusher

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -32,7 +32,11 @@ class ProjectsController < ApplicationController
   end
 
   def show
-    project = find_project_with_slugged_route!
+    if project_show?
+      project = Project.find(params[:id])
+    elsif for_slugged_route?
+      project = find_project_with_slugged_route!
+    end
 
     authorize project
 
@@ -99,6 +103,10 @@ class ProjectsController < ApplicationController
 
     def for_slugged_route?
       slugged_route_slug.present?
+    end
+
+    def project_show?
+      slugged_route_slug == "projects"
     end
 
     def find_project_with_slugged_route!

--- a/app/controllers/slugged_routes_controller.rb
+++ b/app/controllers/slugged_routes_controller.rb
@@ -16,7 +16,7 @@ class SluggedRoutesController < ApplicationController
 
     authorize slugged_route
 
-    render json: slugged_route, include: ["owner"]
+    render json: slugged_route
   end
 
   def slug

--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -17,6 +17,9 @@
 class OrganizationSerializer < ActiveModel::Serializer
   attributes :id, :name, :slug, :icon_thumb_url, :icon_large_url
 
+  has_many :projects
+  has_many :members
+
   def icon_thumb_url
     object.icon.url(:thumb)
   end

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -17,7 +17,7 @@
 #
 
 class ProjectSerializer < ActiveModel::Serializer
-  attributes :id, :title, :description, :icon_thumb_url, :icon_large_url
+  attributes :id, :slug, :title, :description, :icon_thumb_url, :icon_large_url
 
   has_many :github_repositories
 

--- a/app/serializers/slugged_route_serializer.rb
+++ b/app/serializers/slugged_route_serializer.rb
@@ -13,5 +13,5 @@
 class SluggedRouteSerializer < ActiveModel::Serializer
   attributes :id, :slug, :owner_type
 
-  belongs_to :owner
+  belongs_to :owner, polymorphic: true
 end

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -19,6 +19,7 @@
 FactoryGirl.define do
   factory :project do
     sequence(:title) { |n| "Project#{n}" }
+    sequence(:description) { |n| "Project description #{n}" }
 
     association :organization
 

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -20,7 +20,29 @@ describe "Projects API" do
         expect(json).to serialize_collection(@projects).with(ProjectSerializer)
       end
     end
+  end
 
+  context "GET /projects/:id" do
+    before do
+      @project = create(:project, organization: create(:organization))
+      create_list(:github_repository, 10, project: @project)
+    end
+
+    context "when successful" do
+      before do
+        get "#{host}/projects/#{@project.id}"
+      end
+
+      it "responds with a 200" do
+        expect(last_response.status).to eq 200
+      end
+
+      it "returns the specified project" do
+        expect(json).to serialize_object(@project).
+          with(ProjectSerializer).
+          with_includes(:github_repositories)
+      end
+    end
   end
 
   context "GET /:slug/projects" do
@@ -48,7 +70,7 @@ describe "Projects API" do
   context "GET /:slug/:project_slug" do
     before do
       @project = create(:project, organization: create(:organization))
-      github_repositories = create_list(:github_repository, 10, project: @project)
+      create_list(:github_repository, 10, project: @project)
     end
 
     context "when successful" do
@@ -61,7 +83,9 @@ describe "Projects API" do
       end
 
       it "returns the specified project" do
-        expect(json).to serialize_object(@project).with(ProjectSerializer).with_includes(:github_repositories)
+        expect(json).to serialize_object(@project).
+          with(ProjectSerializer).
+          with_includes(:github_repositories)
       end
     end
 

--- a/spec/requests/api/slugged_routes_spec.rb
+++ b/spec/requests/api/slugged_routes_spec.rb
@@ -1,23 +1,20 @@
 require "rails_helper"
 
 describe "Slugged Routes API" do
-
   context "GET /:slug" do
-
     context "when successful" do
       before do
         @slugged_route = create(:organization).slugged_route
         get "#{host}/#{@slugged_route.slug}"
       end
 
-      it"responds with a 200" do
+      it "responds with a 200" do
         expect(last_response.status).to eq 200
       end
 
       it "returns a SluggedRoute, serialized with SluggedRouteSerializer, with owner included" do
         expect(json).to serialize_object(@slugged_route).
-          with(SluggedRouteSerializer).
-          with_includes("owner")
+          with(SluggedRouteSerializer)
       end
     end
 
@@ -33,8 +30,6 @@ describe "Slugged Routes API" do
       it "returns a proper error response" do
         expect(json).to be_a_valid_json_api_error.with_id "RECORD_NOT_FOUND"
       end
-
     end
-
   end
 end

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -50,25 +50,36 @@ describe ProjectSerializer, :type => :serializer do
       it "has a type set to 'projects'" do
         expect(subject["type"]).to eq "projects"
       end
-
-      it "has 'icon url's" do
-        expect(subject["attributes"]["icon_thumb_url"]).to eql resource.icon(:thumb)
-        expect(subject["attributes"]["icon_large_url"]).to eql resource.icon(:large)
-      end
     end
 
     context "attributes" do
-
       subject do
         JSON.parse(serialization.to_json)["data"]["attributes"]
       end
 
       it "has a 'title'" do
+        expect(subject["title"]).to_not be_nil
         expect(subject["title"]).to eql resource.title
       end
 
       it "has a 'description'" do
+        expect(subject["description"]).to_not be_nil
         expect(subject["description"]).to eql resource.description
+      end
+
+      it "has a 'slug'" do
+        expect(subject["slug"]).to_not be_nil
+        expect(subject["slug"]).to eql resource.slug
+      end
+
+      it "has a 'icon_thumb_url'" do
+        expect(subject["icon_thumb_url"]).to_not be_nil
+        expect(subject["icon_thumb_url"]).to eql resource.icon.url(:thumb)
+      end
+
+      it "has a 'icon_large_url'" do
+        expect(subject["icon_large_url"]).to_not be_nil
+        expect(subject["icon_large_url"]).to eql resource.icon.url(:large)
       end
     end
 


### PR DESCRIPTION
- [x] Allow for projects show
- [x] Test for `projects/:id` in API specs
- [x] Add projects to unavailable slugs if not added
- [x] Ensure tests don't include owner
- [x] Test for slugged route serializer
- [x] Test for `has_many` projects in organization
- [x] Test for `has_many` members in organization
- [x] Test for slug in project serializer
