### PR TITLE
Add status field to user mentions. Change behavior so only old mentions of the same status are destroyed on regeneration

### DIFF
--- a/app/controllers/comment_user_mentions_controller.rb
+++ b/app/controllers/comment_user_mentions_controller.rb
@@ -1,0 +1,16 @@
+class CommentUserMentionsController < ApplicationController
+  def index
+    authorize CommentUserMention
+    mentions = CommentUserMention.includes(:user, :comment).where(filter_params)
+    render json: mentions
+  end
+
+  private
+
+    def filter_params
+      {
+        comment_id: params[:comment_id],
+        status: params[:status]
+      }
+    end
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -37,7 +37,7 @@ class CommentsController < ApplicationController
 
     authorize comment
 
-    if comment.update publish?
+    if comment.update(publish?)
       GenerateCommentUserNotificationsWorker.perform_async(comment.id) if publish?
       render json: comment
     else
@@ -52,7 +52,7 @@ class CommentsController < ApplicationController
 
     comment.assign_attributes(update_params)
 
-    if comment.update publish?
+    if comment.update(publish?)
       GenerateCommentUserNotificationsWorker.perform_async(comment.id) if publish?
       render json: comment
     else
@@ -61,6 +61,7 @@ class CommentsController < ApplicationController
   end
 
   private
+
     def publish?
       true unless record_attributes.fetch(:preview, false)
     end

--- a/app/controllers/post_user_mentions_controller.rb
+++ b/app/controllers/post_user_mentions_controller.rb
@@ -1,0 +1,16 @@
+class PostUserMentionsController < ApplicationController
+  def index
+    authorize PostUserMention
+    mentions = PostUserMention.includes(:user, :post).where(filter_params)
+    render json: mentions
+  end
+
+  private
+
+    def filter_params
+      {
+        post_id: params[:post_id],
+        status: params[:status]
+      }
+    end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -41,7 +41,7 @@ class PostsController < ApplicationController
 
     authorize post
 
-    if post.update publish?
+    if post.update(publish?)
       GeneratePostUserNotificationsWorker.perform_async(post.id) if publish?
       render json: post
     else

--- a/app/models/comment_user_mention.rb
+++ b/app/models/comment_user_mention.rb
@@ -27,6 +27,8 @@ class CommentUserMention < ActiveRecord::Base
 
   before_validation :add_username_from_user
 
+  enum status: { preview: "preview", published: "published" }
+
   def indices
     [start_index, end_index]
   end
@@ -34,6 +36,6 @@ class CommentUserMention < ActiveRecord::Base
   private
 
     def add_username_from_user
-      self.username = self.user.username if self.user.present?
+      self.username = user.username if user.present?
     end
 end

--- a/app/models/post_user_mention.rb
+++ b/app/models/post_user_mention.rb
@@ -24,6 +24,8 @@ class PostUserMention < ActiveRecord::Base
 
   before_validation :add_username_from_user
 
+  enum status: { preview: "preview", published: "published" }
+
   def indices
     [start_index, end_index]
   end
@@ -31,6 +33,6 @@ class PostUserMention < ActiveRecord::Base
   private
 
     def add_username_from_user
-      self.username = self.user.username if self.user.present?
+      self.username = user.username if user.present?
     end
 end

--- a/app/policies/comment_user_mention_policy.rb
+++ b/app/policies/comment_user_mention_policy.rb
@@ -1,0 +1,12 @@
+class CommentUserMentionPolicy
+  attr_reader :user, :comment_user_mention
+
+  def initialize(user, comment_user_mention)
+    @user = user
+    @comment_user_mention = comment_user_mention
+  end
+
+  def index?
+    true
+  end
+end

--- a/app/policies/post_user_mention_policy.rb
+++ b/app/policies/post_user_mention_policy.rb
@@ -1,0 +1,12 @@
+class PostUserMentionPolicy
+  attr_reader :user, :post_user_mention
+
+  def initialize(user, post_user_mention)
+    @user = user
+    @post_user_mention = post_user_mention
+  end
+
+  def index?
+    true
+  end
+end

--- a/app/serializers/comment_user_mention_serializer.rb
+++ b/app/serializers/comment_user_mention_serializer.rb
@@ -14,7 +14,7 @@
 #
 
 class CommentUserMentionSerializer < ActiveModel::Serializer
-  attributes :id, :indices, :username
+  attributes :id, :indices, :username, :status
 
   belongs_to :user
   belongs_to :comment, serializer: CommentSerializer

--- a/app/serializers/post_user_mention_serializer.rb
+++ b/app/serializers/post_user_mention_serializer.rb
@@ -13,7 +13,7 @@
 #
 
 class PostUserMentionSerializer < ActiveModel::Serializer
-  attributes :id, :indices, :username
+  attributes :id, :indices, :username, :status
 
   belongs_to :user
   belongs_to :post, serializer: PostSerializerWithoutIncludes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,6 @@ Rails.application.routes.draw do
   end
 
   constraints subdomain: "api" do
-
     get "ping", to: "ping#index"
 
     get "user", to: "users#show_authenticated_user"
@@ -28,7 +27,7 @@ Rails.application.routes.draw do
     resources :skill_categories, only: [:index]
 
     resources :projects, only: [:index, :create, :update] do
-        resources :posts, only: [:index, :show]
+      resources :posts, only: [:index, :show]
     end
 
     resources :posts, only: [:create, :update] do
@@ -42,6 +41,9 @@ Rails.application.routes.draw do
     resources :comment_images, only: [:create]
 
     resources :organizations, only: [:show, :create, :update]
+
+    resources :post_user_mentions, only: [:index]
+    resources :comment_user_mentions, only: [:index]
 
     resources :slugged_routes, path: "", only: [:show] do
       get "projects", to: "projects#index"

--- a/db/migrate/20160225201529_add_status_to_user_mentions.rb
+++ b/db/migrate/20160225201529_add_status_to_user_mentions.rb
@@ -1,0 +1,6 @@
+class AddStatusToUserMentions < ActiveRecord::Migration
+  def change
+    add_column(:comment_user_mentions, :status, :string, null: false, default: "preview")
+    add_column(:post_user_mentions, :status, :string, null: false, default: "preview")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160215223422) do
+ActiveRecord::Schema.define(version: 20160225201529) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,14 +30,15 @@ ActiveRecord::Schema.define(version: 20160215223422) do
   end
 
   create_table "comment_user_mentions", force: :cascade do |t|
-    t.integer  "user_id",     null: false
-    t.integer  "comment_id",  null: false
-    t.integer  "post_id",     null: false
-    t.string   "username",    null: false
-    t.integer  "start_index", null: false
-    t.integer  "end_index",   null: false
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.integer  "user_id",                         null: false
+    t.integer  "comment_id",                      null: false
+    t.integer  "post_id",                         null: false
+    t.string   "username",                        null: false
+    t.integer  "start_index",                     null: false
+    t.integer  "end_index",                       null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
+    t.string   "status",      default: "preview", null: false
   end
 
   create_table "comments", force: :cascade do |t|
@@ -158,13 +159,14 @@ ActiveRecord::Schema.define(version: 20160215223422) do
   end
 
   create_table "post_user_mentions", force: :cascade do |t|
-    t.integer  "user_id",     null: false
-    t.integer  "post_id",     null: false
-    t.string   "username",    null: false
-    t.integer  "start_index", null: false
-    t.integer  "end_index",   null: false
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.integer  "user_id",                         null: false
+    t.integer  "post_id",                         null: false
+    t.string   "username",                        null: false
+    t.integer  "start_index",                     null: false
+    t.integer  "end_index",                       null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
+    t.string   "status",      default: "preview", null: false
   end
 
   create_table "posts", force: :cascade do |t|

--- a/lib/code_corps/scenario/generate_user_mentions_for_comment.rb
+++ b/lib/code_corps/scenario/generate_user_mentions_for_comment.rb
@@ -4,39 +4,67 @@ module CodeCorps
       def initialize(comment)
         @comment = comment
         @post = comment.post
+        @publishing = comment.publishing
       end
+
+      attr_reader :comment, :post, :publishing
+      alias_method :publishing?, :publishing
 
       def call
-        result = []
-        mentions = []
-
-        @comment.body_preview.scan(/\B@((?:(?:(?:[^-\W]-?))*)(?:[^\/\W]\/?)?(?:(?:(?:[^-\W]-?))*)\w+)/) do |temp|
-          username = temp.first
-          start_index = Regexp.last_match.offset(0).first
-          end_index = start_index + username.length
-          result << [ username, [start_index, end_index] ]
-        end
-
-        users = User.where(username: result.map(&:first))
-
-        result.each do |r|
-          users.each do |u|
-            if r.first == u.username
-              mentions << [u, r.last.first, r.last.last]
-            end
-          end
-        end
-
         ActiveRecord::Base.transaction do
-          existing_mentions = CommentUserMention.where(comment: @comment)
-          if existing_mentions.present?
-            existing_mentions.destroy_all
-          end
+          destroy_existing_mentions
           mentions.each do |m|
-            CommentUserMention.create!(comment: @comment, post: @post, user: m[0], start_index: m[1], end_index: m[2], username: m[0].username)
+            CommentUserMention.create!(
+              comment: comment, post: post, user: m[0], status: status,
+              start_index: m[1], end_index: m[2], username: m[0].username
+            )
           end
         end
       end
+
+      private
+
+        def status
+          publishing ? :published : :preview
+        end
+
+        def destroy_existing_mentions
+          existing_mentions = comment.comment_user_mentions.published if publishing?
+          existing_mentions = comment.comment_user_mentions.preview unless publishing?
+          existing_mentions.destroy_all if existing_mentions.present?
+        end
+
+        def regex_matches
+          regex = %r{\B@((?:(?:(?:[^-\W]-?))*)(?:[^\/\W]\/?)?(?:(?:(?:[^-\W]-?))*)\w+)}
+
+          result = []
+
+          content = publishing ? comment.body : comment.body_preview
+
+          content.scan(regex) do |temp|
+            username = temp.first
+            start_index = Regexp.last_match.offset(0).first
+            end_index = start_index + username.length
+            result << [username, [start_index, end_index]]
+          end
+
+          result
+        end
+
+        def mentions
+          matches = regex_matches
+          users = User.where(username: matches.map(&:first))
+
+          result = []
+
+          matches.each do |r|
+            users.each do |u|
+              result << [u, r.last.first, r.last.last] if r.first == u.username
+            end
+          end
+
+          result
+        end
     end
   end
 end

--- a/lib/code_corps/scenario/generate_user_mentions_for_post.rb
+++ b/lib/code_corps/scenario/generate_user_mentions_for_post.rb
@@ -3,39 +3,68 @@ module CodeCorps
     class GenerateUserMentionsForPost
       def initialize(post)
         @post = post
+        @publishing = post.publishing
       end
+
+      attr_reader :post, :publishing
+      alias_method :publishing?, :publishing
 
       def call
-        result = []
-        mentions = []
-
-        @post.body_preview.scan(/\B@((?:(?:(?:[^-\W]-?))*)(?:[^\/\W]\/?)?(?:(?:(?:[^-\W]-?))*)\w+)/) do |temp|
-          username = temp.first
-          start_index = Regexp.last_match.offset(0).first
-          end_index = start_index + username.length
-          result << [ username, [start_index, end_index] ]
-        end
-
-        users = User.where(username: result.map(&:first))
-
-        result.each do |r|
-          users.each do |u|
-            if r.first == u.username
-              mentions << [u, r.last.first, r.last.last]
-            end
-          end
-        end
-
         ActiveRecord::Base.transaction do
-          existing_mentions = PostUserMention.where(post: @post)
-          if existing_mentions.present?
-            existing_mentions.destroy_all
-          end
+          destroy_existing_mentions
           mentions.each do |m|
-            PostUserMention.create!(post: @post, user: m[0], start_index: m[1], end_index: m[2], username: m[0].username)
+            PostUserMention.create!(
+              post: @post, user: m[0],
+              start_index: m[1], end_index: m[2],
+              username: m[0].username, status: status
+            )
           end
         end
       end
+
+      private
+
+        def status
+          publishing? ? :published : :preview
+        end
+
+        def destroy_existing_mentions
+          existing_mentions = post.post_user_mentions.published if publishing?
+          existing_mentions = post.post_user_mentions.preview unless publishing?
+          existing_mentions.destroy_all if existing_mentions.present?
+        end
+
+        def regex_matches
+          regex = %r{\B@((?:(?:(?:[^-\W]-?))*)(?:[^\/\W]\/?)?(?:(?:(?:[^-\W]-?))*)\w+)}
+
+          result = []
+
+          content = publishing? ? post.body : post.body_preview
+
+          content.scan(regex) do |temp|
+            username = temp.first
+            start_index = Regexp.last_match.offset(0).first
+            end_index = start_index + username.length
+            result << [username, [start_index, end_index]]
+          end
+
+          result
+        end
+
+        def mentions
+          matches = regex_matches
+          users = User.where(username: matches.map(&:first))
+
+          result = []
+
+          matches.each do |r|
+            users.each do |u|
+              result << [u, r.last.first, r.last.last] if r.first == u.username
+            end
+          end
+
+          result
+        end
     end
   end
 end

--- a/spec/lib/code_corps/scenario/generate_notifications_for_comment_user_mentions_spec.rb
+++ b/spec/lib/code_corps/scenario/generate_notifications_for_comment_user_mentions_spec.rb
@@ -5,7 +5,6 @@ module CodeCorps
   module Scenario
     describe GenerateNotificationsForCommentUserMentions do
       describe "#call" do
-
         let(:user) { create(:user) }
         let(:comment) { create(:comment) }
 

--- a/spec/lib/code_corps/scenario/generate_notifications_for_post_user_mentions_spec.rb
+++ b/spec/lib/code_corps/scenario/generate_notifications_for_post_user_mentions_spec.rb
@@ -5,7 +5,6 @@ module CodeCorps
   module Scenario
     describe GenerateNotificationsForPostUserMentions do
       describe "#call" do
-
         let(:user) { create(:user) }
         let(:post) { create(:post) }
 

--- a/spec/lib/code_corps/scenario/generate_user_mentions_for_comment_spec.rb
+++ b/spec/lib/code_corps/scenario/generate_user_mentions_for_comment_spec.rb
@@ -5,26 +5,61 @@ module CodeCorps
   module Scenario
     describe GenerateUserMentionsForComment do
       describe "#call" do
+        let(:user) { create(:user, username: "joshsmith") }
 
-        let(:mentioned_username) { "joshsmith" }
+        it "creates user mentions for body_preview when previewing" do
+          comment = create(:comment, markdown_preview: "Mentioning @#{user.username}")
 
-        before do
-          @mentioned_user = create(:user, username: mentioned_username)
-        end
-
-        it "creates user mentions" do
-          comment = build(:comment, markdown_preview: "Mentioning @joshsmith")
-          comment.update
-
+          comment.publishing = false
           GenerateUserMentionsForComment.new(comment).call
 
           mention = CommentUserMention.last
           expect(mention.comment).to eq comment
-          expect(mention.user).to eq @mentioned_user
-          expect(mention.username).to eq mentioned_username
+          expect(mention.user).to eq user
+          expect(mention.username).to eq user.username
 
           post = comment.post
           expect(post.comment_user_mentions).to include mention
+        end
+
+        it "creates user mentions from body when publishing" do
+          comment = create(:comment, markdown_preview: "Mentioning @#{user.username}")
+
+          comment.publishing = true
+          GenerateUserMentionsForComment.new(comment).call
+
+          mention = CommentUserMention.last
+          expect(mention.comment).to eq comment
+          expect(mention.user).to eq user
+          expect(mention.username).to eq user.username
+
+          post = comment.post
+          expect(post.comment_user_mentions).to include mention
+        end
+
+        context "when mentions already exist" do
+          let(:comment) { create(:comment) }
+
+          before do
+            create_list(:comment_user_mention, 2, comment: comment, status: :published)
+            create_list(:comment_user_mention, 3, comment: comment, status: :preview)
+          end
+
+          it "destroys preview mentions if preview was requested, leaves published mentions" do
+            comment.publishing = false
+            comment.body_preview = "@#{user.username}"
+            GenerateUserMentionsForComment.new(comment).call
+            expect(comment.comment_user_mentions.published.count).to eq 2
+            expect(comment.comment_user_mentions.preview.count).to eq 1
+          end
+
+          it "destroys published mentions if publish was requested, leaves preview mentions" do
+            comment.publishing = true
+            comment.body = "@#{user.username}"
+            GenerateUserMentionsForComment.new(comment).call
+            expect(comment.comment_user_mentions.published.count).to eq 1
+            expect(comment.comment_user_mentions.preview.count).to eq 3
+          end
         end
       end
     end

--- a/spec/lib/code_corps/scenario/generate_user_mentions_for_post_spec.rb
+++ b/spec/lib/code_corps/scenario/generate_user_mentions_for_post_spec.rb
@@ -5,23 +5,55 @@ module CodeCorps
   module Scenario
     describe GenerateUserMentionsForPost do
       describe "#call" do
+        let(:user) { create(:user, username: "joshsmith") }
 
-        let(:mentioned_username) { "joshsmith" }
+        it "creates user mentions for body_preview when previewing" do
+          post = create(:post, markdown_preview: "Mentioning @#{user.username}")
 
-        before do
-          @mentioned_user = create(:user, username: mentioned_username)
-        end
-
-        it "creates user mentions" do
-          post = build(:post, markdown_preview: "Mentioning @joshsmith")
-          post.update
-
+          post.publishing = false
           GenerateUserMentionsForPost.new(post).call
 
           mention = PostUserMention.last
           expect(mention.post).to eq post
-          expect(mention.user).to eq @mentioned_user
-          expect(mention.username).to eq mentioned_username
+          expect(mention.user).to eq user
+          expect(mention.username).to eq user.username
+        end
+
+        it "creates user mentions from body when publishing" do
+          post = create(:post, markdown_preview: "Mentioning @#{user.username}")
+
+          post.publishing = true
+          GenerateUserMentionsForPost.new(post).call
+
+          mention = PostUserMention.last
+          expect(mention.post).to eq post
+          expect(mention.user).to eq user
+          expect(mention.username).to eq user.username
+        end
+
+        context "when mentions already exist" do
+          let(:post) { create(:post) }
+
+          before do
+            create_list(:post_user_mention, 2, post: post, status: :published)
+            create_list(:post_user_mention, 3, post: post, status: :preview)
+          end
+
+          it "destroys preview mentions if preview was requested, leaves published mentions" do
+            post.publishing = false
+            post.body_preview = "@#{user.username}"
+            GenerateUserMentionsForPost.new(post).call
+            expect(post.post_user_mentions.published.count).to eq 2
+            expect(post.post_user_mentions.preview.count).to eq 1
+          end
+
+          it "destroys published mentions if publish was requested, leaves preview mentions" do
+            post.publishing = true
+            post.body = "@#{user.username}"
+            GenerateUserMentionsForPost.new(post).call
+            expect(post.post_user_mentions.published.count).to eq 1
+            expect(post.post_user_mentions.preview.count).to eq 3
+          end
         end
       end
     end

--- a/spec/models/comment_user_mention_spec.rb
+++ b/spec/models/comment_user_mention_spec.rb
@@ -13,8 +13,6 @@
 #  updated_at  :datetime         not null
 #
 
-require 'rails_helper'
-
 RSpec.describe CommentUserMention, type: :model do
   describe "schema" do
     it { should have_db_column(:comment_id).of_type(:integer).with_options(null: false) }
@@ -23,6 +21,9 @@ RSpec.describe CommentUserMention, type: :model do
     it { should have_db_column(:username).of_type(:string).with_options(null: false) }
     it { should have_db_column(:start_index).of_type(:integer).with_options(null: false) }
     it { should have_db_column(:end_index).of_type(:integer).with_options(null: false) }
+    it do
+      should have_db_column(:status).of_type(:string).with_options(null: false, default: "preview")
+    end
     it { should have_db_column(:updated_at) }
     it { should have_db_column(:created_at) }
   end
@@ -42,6 +43,10 @@ RSpec.describe CommentUserMention, type: :model do
     it { should validate_presence_of(:end_index) }
   end
 
+  describe "behavior" do
+    it { should define_enum_for(:status).with(preview: "preview", published: "published") }
+  end
+
   describe "before_validation" do
     it "automatically adds the user's username" do
       user = create(:user, username: "joshsmith")
@@ -53,7 +58,7 @@ RSpec.describe CommentUserMention, type: :model do
   describe "indices" do
     it "wraps the indices inside of an array" do
       mention = create(:comment_user_mention, start_index: 0, end_index: 140)
-      expect(mention.indices).to eq [0,140]
+      expect(mention.indices).to eq [0, 140]
     end
   end
 end

--- a/spec/models/post_user_mention_spec.rb
+++ b/spec/models/post_user_mention_spec.rb
@@ -12,8 +12,6 @@
 #  updated_at  :datetime         not null
 #
 
-require 'rails_helper'
-
 RSpec.describe PostUserMention, type: :model do
   describe "schema" do
     it { should have_db_column(:post_id).of_type(:integer).with_options(null: false) }
@@ -21,6 +19,9 @@ RSpec.describe PostUserMention, type: :model do
     it { should have_db_column(:username).of_type(:string).with_options(null: false) }
     it { should have_db_column(:start_index).of_type(:integer).with_options(null: false) }
     it { should have_db_column(:end_index).of_type(:integer).with_options(null: false) }
+    it do
+      should have_db_column(:status).of_type(:string).with_options(null: false, default: "preview")
+    end
     it { should have_db_column(:updated_at) }
     it { should have_db_column(:created_at) }
   end
@@ -38,6 +39,10 @@ RSpec.describe PostUserMention, type: :model do
     it { should validate_presence_of(:end_index) }
   end
 
+  describe "behavior" do
+    it { should define_enum_for(:status).with(preview: "preview", published: "published") }
+  end
+
   describe "before_validation" do
     it "automatically adds the user's username" do
       user = create(:user, username: "joshsmith")
@@ -49,7 +54,7 @@ RSpec.describe PostUserMention, type: :model do
   describe "indices" do
     it "wraps the indices inside of an array" do
       mention = create(:post_user_mention, start_index: 0, end_index: 140)
-      expect(mention.indices).to eq [0,140]
+      expect(mention.indices).to eq [0, 140]
     end
   end
 end

--- a/spec/policies/comment_user_mention_policy_spec.rb
+++ b/spec/policies/comment_user_mention_policy_spec.rb
@@ -1,0 +1,9 @@
+describe CommentUserMentionPolicy do
+  subject { described_class }
+
+  permissions :index? do
+    it "is permited for anyone" do
+      expect(subject).to permit(nil, nil)
+    end
+  end
+end

--- a/spec/policies/post_user_mention_policy_spec.rb
+++ b/spec/policies/post_user_mention_policy_spec.rb
@@ -1,0 +1,9 @@
+describe PostUserMentionPolicy do
+  subject { described_class }
+
+  permissions :index? do
+    it "is permited for anyone" do
+      expect(subject).to permit(nil, nil)
+    end
+  end
+end

--- a/spec/requests/api/comment_user_mentions_spec.rb
+++ b/spec/requests/api/comment_user_mentions_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+describe "CommentUserMentions API" do
+  context "GET /comment_user_mentions/" do
+    let(:comment_a) do
+      comment = create(:comment)
+      create_list(:comment_user_mention, 4, comment: comment, status: :preview)
+      create_list(:comment_user_mention, 3, comment: comment, status: :published)
+      comment
+    end
+
+    let(:comment_b) do
+      comment = create(:comment)
+      create_list(:comment_user_mention, 1, comment: comment, status: :preview)
+      create_list(:comment_user_mention, 2, comment: comment, status: :published)
+      comment
+    end
+
+    def make_request_for_comment(comment, status)
+      get "#{host}/comment_user_mentions/", status: status, comment_id: comment.id
+    end
+
+    it "fetches mentions of specified status for specified comment" do
+      make_request_for_comment(comment_a, :preview)
+      expect(last_response.status).to eq 200
+      expect(json).to(
+        serialize_collection(comment_a.comment_user_mentions.preview).
+          with(CommentUserMentionSerializer)
+      )
+
+      make_request_for_comment(comment_a, :published)
+      expect(last_response.status).to eq 200
+      expect(json).to(
+        serialize_collection(comment_a.comment_user_mentions.published).
+          with(CommentUserMentionSerializer)
+      )
+
+      make_request_for_comment(comment_b, :preview)
+      expect(last_response.status).to eq 200
+      expect(json).to(
+        serialize_collection(comment_b.comment_user_mentions.preview).
+          with(CommentUserMentionSerializer)
+      )
+
+      make_request_for_comment(comment_b, :published)
+      expect(last_response.status).to eq 200
+      expect(json).to(
+        serialize_collection(comment_b.comment_user_mentions.published).
+          with(CommentUserMentionSerializer)
+      )
+    end
+  end
+end

--- a/spec/requests/api/comments_spec.rb
+++ b/spec/requests/api/comments_spec.rb
@@ -314,24 +314,6 @@ describe "Comments API" do
             expect(ActionMailer::Base.deliveries.count).to eq 2
           end
         end
-
-        context "when the attributes are invalid" do
-          let(:invalid_attributes) do
-            {
-              data: {
-                attributes: {
-                  markdown_preview: nil
-                }
-              }
-            }
-          end
-
-          it "responds with a 422 validation error" do
-            make_request invalid_attributes
-            expect(last_response.status).to eq 422
-            expect(json).to be_a_valid_json_api_validation_error
-          end
-        end
       end
 
       context "when comment is published" do

--- a/spec/requests/api/post_user_mentions_spec.rb
+++ b/spec/requests/api/post_user_mentions_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+describe "PostUserMentions API" do
+  context "GET /post_user_mentions/" do
+    let(:post_a) do
+      post = create(:post)
+      create_list(:post_user_mention, 4, post: post, status: :preview)
+      create_list(:post_user_mention, 3, post: post, status: :published)
+      post
+    end
+
+    let(:post_b) do
+      post = create(:post)
+      create_list(:post_user_mention, 1, post: post, status: :preview)
+      create_list(:post_user_mention, 2, post: post, status: :published)
+      post
+    end
+
+    def make_request_for_post(post, status)
+      get "#{host}/post_user_mentions/", status: status, post_id: post.id
+    end
+
+    it "fetches mentions of specified status for specified post" do
+      make_request_for_post(post_a, :preview)
+      expect(last_response.status).to eq 200
+      expect(json).to(
+        serialize_collection(post_a.post_user_mentions.preview).
+          with(PostUserMentionSerializer)
+      )
+
+      make_request_for_post(post_a, :published)
+      expect(last_response.status).to eq 200
+      expect(json).to(
+        serialize_collection(post_a.post_user_mentions.published).
+          with(PostUserMentionSerializer)
+      )
+
+      make_request_for_post(post_b, :preview)
+      expect(last_response.status).to eq 200
+      expect(json).to(
+        serialize_collection(post_b.post_user_mentions.preview).
+          with(PostUserMentionSerializer)
+      )
+
+      make_request_for_post(post_b, :published)
+      expect(last_response.status).to eq 200
+      expect(json).to(
+        serialize_collection(post_b.post_user_mentions.published).
+          with(PostUserMentionSerializer)
+      )
+    end
+  end
+end

--- a/spec/requests/api/posts_spec.rb
+++ b/spec/requests/api/posts_spec.rb
@@ -426,27 +426,6 @@ describe "Posts API" do
             expect(ActionMailer::Base.deliveries.count).to eq 2
           end
         end
-
-        context "when the attributes are invalid" do
-          let(:invalid_attributes) do
-            {
-              data: {
-                attributes: {
-                  title: "", markdown_preview: ""
-                },
-                relationships: {
-                  project: { data: { id: project.id, type: "projects" } }
-                }
-              }
-            }
-          end
-
-          it "responds with a 422 validation error" do
-            authenticated_patch "/posts/#{post.id}", invalid_attributes, token
-            expect(last_response.status).to eq 422
-            expect(json).to be_a_valid_json_api_validation_error
-          end
-        end
       end
 
       context "when post is published" do

--- a/spec/serializers/comment_user_mention_serializer_spec.rb
+++ b/spec/serializers/comment_user_mention_serializer_spec.rb
@@ -15,8 +15,7 @@
 
 require "rails_helper"
 
-describe CommentUserMentionSerializer, :type => :serializer do
-
+describe CommentUserMentionSerializer, type: :serializer do
   context "individual resource representation" do
     let(:resource) { create(:comment_user_mention) }
 
@@ -42,7 +41,6 @@ describe CommentUserMentionSerializer, :type => :serializer do
     end
 
     context "attributes" do
-
       subject do
         JSON.parse(serialization.to_json)["data"]["attributes"]
       end
@@ -53,6 +51,11 @@ describe CommentUserMentionSerializer, :type => :serializer do
 
       it "has 'indices'" do
         expect(subject["indices"]).to eql resource.indices
+      end
+
+      it "has 'status'" do
+        expect(subject["status"]).not_to be_nil
+        expect(subject["status"]).to eql resource.status
       end
     end
 
@@ -86,7 +89,9 @@ describe CommentUserMentionSerializer, :type => :serializer do
       end
 
       context "when including 'user'" do
-        let(:serialization) { ActiveModel::Serializer::Adapter.create(serializer, include: ["user"]) }
+        let(:serialization) do
+          ActiveModel::Serializer::Adapter.create(serializer, include: ["user"])
+        end
 
         subject do
           JSON.parse(serialization.to_json)["included"]
@@ -94,12 +99,14 @@ describe CommentUserMentionSerializer, :type => :serializer do
 
         it "should not be empty" do
           expect(subject).not_to be_nil
-          expect(subject.select{ |i| i["type"] == "users"}.length).to eq 1
+          expect(subject.count { |i| i["type"] == "users" }).to eq 1
         end
       end
 
       context "when including 'comment'" do
-        let(:serialization) { ActiveModel::Serializer::Adapter.create(serializer, include: ["comment"]) }
+        let(:serialization) do
+          ActiveModel::Serializer::Adapter.create(serializer, include: ["comment"])
+        end
 
         subject do
           JSON.parse(serialization.to_json)["included"]
@@ -107,7 +114,7 @@ describe CommentUserMentionSerializer, :type => :serializer do
 
         it "should not be empty" do
           expect(subject).not_to be_nil
-          expect(subject.select{ |i| i["type"] == "comments"}.length).to eq 1
+          expect(subject.count { |i| i["type"] == "comments" }).to eq 1
         end
       end
     end

--- a/spec/serializers/post_user_mention_serializer_spec.rb
+++ b/spec/serializers/post_user_mention_serializer_spec.rb
@@ -14,8 +14,7 @@
 
 require "rails_helper"
 
-describe PostUserMentionSerializer, :type => :serializer do
-
+describe PostUserMentionSerializer, type: :serializer do
   context "individual resource representation" do
     let(:resource) { create(:post_user_mention) }
 
@@ -41,7 +40,6 @@ describe PostUserMentionSerializer, :type => :serializer do
     end
 
     context "attributes" do
-
       subject do
         JSON.parse(serialization.to_json)["data"]["attributes"]
       end
@@ -52,6 +50,11 @@ describe PostUserMentionSerializer, :type => :serializer do
 
       it "has 'indices'" do
         expect(subject["indices"]).to eql resource.indices
+      end
+
+      it "has 'status'" do
+        expect(subject["status"]).not_to be_nil
+        expect(subject["status"]).to eql resource.status
       end
     end
 
@@ -85,7 +88,9 @@ describe PostUserMentionSerializer, :type => :serializer do
       end
 
       context "when including 'user'" do
-        let(:serialization) { ActiveModel::Serializer::Adapter.create(serializer, include: ["user"]) }
+        let(:serialization) do
+          ActiveModel::Serializer::Adapter.create(serializer, include: ["user"])
+        end
 
         subject do
           JSON.parse(serialization.to_json)["included"]
@@ -93,12 +98,14 @@ describe PostUserMentionSerializer, :type => :serializer do
 
         it "should not be empty" do
           expect(subject).not_to be_nil
-          expect(subject.select{ |i| i["type"] == "users"}.length).to eq 1
+          expect(subject.count { |i| i["type"] == "users" }).to eq 1
         end
       end
 
       context "when including 'post'" do
-        let(:serialization) { ActiveModel::Serializer::Adapter.create(serializer, include: ["post"]) }
+        let(:serialization) do
+          ActiveModel::Serializer::Adapter.create(serializer, include: ["post"])
+        end
 
         subject do
           JSON.parse(serialization.to_json)["included"]
@@ -106,7 +113,7 @@ describe PostUserMentionSerializer, :type => :serializer do
 
         it "should not be empty" do
           expect(subject).not_to be_nil
-          expect(subject.select{ |i| i["type"] == "posts"}.length).to eq 1
+          expect(subject.count { |i| i["type"] == "posts" }).to eq 1
         end
       end
     end


### PR DESCRIPTION
This is done and the specs cover the behavior, but I would like to check for some refactoring potential before merging tomorrow. Here's what we have:
- `GET /comment_user_mentions` endpoint
- `GET /post_user_mentions` endpoint
- both endpoint accept a `comment/post_id` and a `status` parameter
- neither of the endpoints requires logging in
- modified behavior of scenarios for generating user mentions
  - if we're publishing a post, mentions are generated from `body` and old mentions with status `published` are being destroyed.
  - if we're previewing a post, mentions are generated from `body_preview` and old mentions with status `preview` are being destroyed
- the `update` method has been modified further. It now calls the generation of mentions explicitly, instead of this being left to `after_save`. The reason for that is, we have to pass in a boolean to indicate if we're doing it for a publish or a preview. **This is the main thing I would like to rewrite in a nicer way**.
