### PR TITLE
Refactor Post to move likes_count into serializer

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -84,10 +84,6 @@ class Post < ActiveRecord::Base
 
   scope :active, -> { where("aasm_state=? OR aasm_state=?", "published", "edited") }
 
-  def likes_count
-    post_likes_count
-  end
-
   def update(publishing)
     @publishing = publishing
     save

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -32,4 +32,8 @@ class PostSerializer < ActiveModel::Serializer
 
   belongs_to :user
   belongs_to :project
+
+  def likes_count
+    object.post_likes_count
+  end
 end

--- a/app/serializers/post_serializer_without_includes.rb
+++ b/app/serializers/post_serializer_without_includes.rb
@@ -1,3 +1,10 @@
 class PostSerializerWithoutIncludes < ActiveModel::Serializer
-  attributes :id, :title, :body, :status, :post_type, :likes_count, :number
+  attributes :id, :number, :post_type, :state, :status,
+             :title, :body, :body_preview, :markdown, :markdown_preview,
+             :likes_count, :comments_count,
+             :edited_at
+
+  def likes_count
+    object.post_likes_count
+  end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -119,14 +119,14 @@ describe Post, type: :model do
 
     context "when there is no PostLike" do
       it "should have the correct counter cache" do
-        expect(post.likes_count).to eq 0
+        expect(post.post_likes_count).to eq 0
       end
     end
 
     context "when there is a PostLike" do
       it "should have the correct counter cache" do
         create(:post_like, user: user, post: post)
-        expect(post.likes_count).to eq 1
+        expect(post.post_likes_count).to eq 1
       end
     end
   end

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -97,20 +97,23 @@ describe PostSerializer, type: :serializer do
       end
 
       it "has a 'status'" do
+        expect(subject["status"]).to_not be_nil
         expect(subject["status"]).to eql resource.status
-      end
-
-      it "has a 'post_type'" do
-        expect(subject["post_type"]).to eql resource.post_type
-      end
-
-      it "has a 'likes_count'" do
-        expect(subject["likes_count"]).to eql resource.likes_count
       end
 
       it "has a 'number'" do
         expect(subject["number"]).to_not be_nil
         expect(subject["number"]).to eql resource.number
+      end
+
+      it "has a 'post_type'" do
+        expect(subject["post_type"]).to_not be_nil
+        expect(subject["post_type"]).to eql resource.post_type
+      end
+
+      it "has a 'likes_count'" do
+        expect(subject["likes_count"]).to_not be_nil
+        expect(subject["likes_count"]).to eql resource.post_likes_count
       end
 
       it "has a 'state'" do
@@ -120,6 +123,7 @@ describe PostSerializer, type: :serializer do
       it "has an 'edited_at'" do
         expect(subject["edited_at"]).to be_the_same_time_as resource.edited_at
       end
+
       it "has a 'comments_count'" do
         expect(subject["comments_count"]).to eql resource.comments_count
       end

--- a/spec/serializers/post_serializer_without_includes_spec.rb
+++ b/spec/serializers/post_serializer_without_includes_spec.rb
@@ -10,6 +10,9 @@ describe PostSerializerWithoutIncludes, :type => :serializer do
         project: create(:project),
         number: 1)
 
+      post.publish!
+      post.edit!
+
       create_list(:comment, 10, post: post)
       post.reload
     }
@@ -41,8 +44,27 @@ describe PostSerializerWithoutIncludes, :type => :serializer do
       end
 
       it "has a 'title'" do
-        expect(subject["title"]).to_not be_nil
         expect(subject["title"]).to eql resource.title
+      end
+
+      it "has a 'body'" do
+        expect(subject["body"]).not_to be_nil
+        expect(subject["body"]).to eql resource.body
+      end
+
+      it "has 'markdown'" do
+        expect(subject["markdown"]).not_to be_nil
+        expect(subject["markdown"]).to eql resource.markdown
+      end
+
+      it "has a 'body_preview'" do
+        expect(subject["body_preview"]).not_to be_nil
+        expect(subject["body_preview"]).to eql resource.body_preview
+      end
+
+      it "has 'markdown_preview'" do
+        expect(subject["markdown_preview"]).not_to be_nil
+        expect(subject["markdown_preview"]).to eql resource.markdown_preview
       end
 
       it "has a 'status'" do
@@ -62,7 +84,19 @@ describe PostSerializerWithoutIncludes, :type => :serializer do
 
       it "has a 'likes_count'" do
         expect(subject["likes_count"]).to_not be_nil
-        expect(subject["likes_count"]).to eql resource.likes_count
+        expect(subject["likes_count"]).to eql resource.post_likes_count
+      end
+
+      it "has a 'state'" do
+        expect(subject["state"]).to eql resource.state
+      end
+
+      it "has an 'edited_at'" do
+        expect(subject["edited_at"]).to be_the_same_time_as resource.edited_at
+      end
+
+      it "has a 'comments_count'" do
+        expect(subject["comments_count"]).to eql resource.comments_count
       end
     end
 


### PR DESCRIPTION
This is really decoration and should not be the responsibility of the model.

Also added tests that were missing.
