### PR TITLE
Fix crash during mention generation when body content is nil

### DIFF
--- a/lib/code_corps/scenario/generate_user_mentions_for_post.rb
+++ b/lib/code_corps/scenario/generate_user_mentions_for_post.rb
@@ -41,6 +41,8 @@ module CodeCorps
 
           content = publishing? ? post.body : post.body_preview
 
+          return if content.nil?
+
           content.scan(regex) do |temp|
             username = temp.first
             start_index = Regexp.last_match.offset(0).first

--- a/spec/factories/comment_factory.rb
+++ b/spec/factories/comment_factory.rb
@@ -19,8 +19,6 @@ FactoryGirl.define do
   factory :comment do
     sequence(:markdown) { |n| "Comment #{n}" }
     sequence(:markdown_preview) { |n| "Comment #{n}" }
-    sequence(:body) { |n| "<p>Comment #{n}</p>" }
-    sequence(:body_preview) { |n| "<p>Comment #{n}</p>" }
 
     association :post
     association :user

--- a/spec/factories/post_factory.rb
+++ b/spec/factories/post_factory.rb
@@ -26,8 +26,6 @@ FactoryGirl.define do
     sequence(:title) { |n| "Post #{n}" }
     sequence(:markdown) { |n| "Post content #{n}" }
     sequence(:markdown_preview) { |n| "Post content #{n}" }
-    sequence(:body) { |n| "<p>Post content #{n}</p>" }
-    sequence(:body_preview) { |n| "<p>Post content #{n}</p>" }
 
     association :user
     association :project

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -144,8 +144,8 @@ describe Post, type: :model do
     context "when published with bang (auto-save) methods" do
       it "numbers posts for each project" do
         project = create(:project)
-        first_post = create(:post, project: project)
-        second_post = create(:post, project: project)
+        first_post = create(:post, project: project, body: "A body")
+        second_post = create(:post, project: project, body: "A body")
         first_post.publish!
         second_post.publish!
 
@@ -155,7 +155,7 @@ describe Post, type: :model do
 
       it "should not allow a duplicate number to be set for the same project" do
         project = create(:project)
-        first_post = create(:post, project: project)
+        first_post = create(:post, project: project, body: "A body")
         first_post.publish!
 
         expect { create(:post, project: project, number: 1) }.to raise_error ActiveRecord::RecordInvalid

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -30,6 +30,7 @@ describe PostSerializer, type: :serializer do
       title: "Post title",
       user: create(:user),
       project: create(:project),
+      body: "Random body",
       number: 1
     )
 

--- a/spec/serializers/post_serializer_without_includes_spec.rb
+++ b/spec/serializers/post_serializer_without_includes_spec.rb
@@ -8,6 +8,7 @@ describe PostSerializerWithoutIncludes, :type => :serializer do
         title: "Post title",
         user: create(:user),
         project: create(:project),
+        body: "Some body",
         number: 1)
 
       post.publish!

--- a/spec/workers/generate_comment_user_notifications_worker_spec.rb
+++ b/spec/workers/generate_comment_user_notifications_worker_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 describe GenerateCommentUserNotificationsWorker do
 
-  let(:draft_comment) { create(:comment, :with_user_mentions, mention_count: 4,  aasm_state: "draft") }
-  let(:published_comment) { create(:comment, :with_user_mentions, mention_count: 4,  aasm_state: "published") }
+  let(:draft_comment) { create(:comment, :draft, :with_user_mentions, mention_count: 4) }
+  let(:published_comment) { create(:comment, :published, :with_user_mentions, mention_count: 4) }
 
   context "when there are no pre-existing notifications" do
     context "when the comment is a draft" do

--- a/spec/workers/generate_post_user_notifications_worker_spec.rb
+++ b/spec/workers/generate_post_user_notifications_worker_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 describe GeneratePostUserNotificationsWorker do
 
-  let(:draft_post) { create(:post, :with_user_mentions, mention_count: 4, aasm_state: "draft") }
-  let(:published_post) { create(:post, :with_user_mentions, mention_count: 4, aasm_state: "published") }
+  let(:draft_post) { create(:post, :draft, :with_user_mentions, mention_count: 4) }
+  let(:published_post) { create(:post, :published, :with_user_mentions, mention_count: 4) }
 
   context "when there are no pre-existing notifications" do
     context "when the post is a draft" do


### PR DESCRIPTION
Closes #256 

Our post and comment factories are becoming a bit problematic due to the combination of hooks and validations we have, but I managed to work around it for now. I would like to improve it a bit, so I created an issue for it - #261

The behavior implemented here to deal with the `nil` issue is simply to treat `nil` values as if they were empty strings - `""`.
