### PR TITLE
Add ProjectRole

### DIFF
--- a/app/controllers/project_roles_controller.rb
+++ b/app/controllers/project_roles_controller.rb
@@ -1,0 +1,44 @@
+class ProjectRolesController < ApplicationController
+  before_action :doorkeeper_authorize!
+  before_action :require_params, only: [:create]
+
+  def create
+    project_role = ProjectRole.new(create_params)
+
+    if project_role.project.blank?
+      project_role.valid?
+      render_validation_errors project_role.errors
+      return
+    end
+
+    authorize project_role
+
+    if project_role.valid?
+      project_role.save!
+      render json: project_role, include: [:role, :project]
+    else
+      render_validation_errors project_role.errors
+    end
+  end
+
+  def destroy
+    project_role = ProjectRole.find(params[:id])
+
+    authorize project_role
+
+    project_role.destroy!
+
+    render json: :nothing, status: :no_content
+  end
+
+  private
+
+    def require_params
+      require_param :role_id
+      require_param :project_id
+    end
+
+    def create_params
+      parse_params(params)
+    end
+end

--- a/app/controllers/project_roles_controller.rb
+++ b/app/controllers/project_roles_controller.rb
@@ -5,15 +5,8 @@ class ProjectRolesController < ApplicationController
   def create
     project_role = ProjectRole.new(create_params)
 
-    if project_role.project.blank?
-      project_role.valid?
-      render_validation_errors project_role.errors
-      return
-    end
-
-    authorize project_role
-
     if project_role.valid?
+      authorize project_role
       project_role.save!
       render json: project_role, include: [:role, :project]
     else

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -26,7 +26,7 @@ class ProjectsController < ApplicationController
       projects = find_projects_with_slugged_route!
     else
       projects = Project.all.includes(
-        :categories, :github_repositories, :organization,
+        :categories, :github_repositories, :organization, :roles
       )
     end
 
@@ -101,7 +101,7 @@ class ProjectsController < ApplicationController
 
     def find_project_with_slugged_route!
       slugged_route = find_slugged_route!
-      Project.includes(:categories, :github_repositories, :organization).
+      Project.includes(:categories, :github_repositories, :organization, :roles).
         where("lower(slug) = ?", project_slug.downcase).
         find_by!(organization: slugged_route.owner)
     end
@@ -109,7 +109,7 @@ class ProjectsController < ApplicationController
     def find_projects_with_slugged_route!
       slugged_route = find_slugged_route!
       Project.
-        includes(:categories, :github_repositories, :organization).
+        includes(:categories, :github_repositories, :organization, :roles).
         where(organization: slugged_route.owner)
     end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -23,6 +23,8 @@ class Project < ActiveRecord::Base
 
   has_many :project_categories
   has_many :categories, through: :project_categories
+  has_many :project_roles
+  has_many :roles, through: :project_roles
   has_many :github_repositories
   has_many :posts
 

--- a/app/models/project_role.rb
+++ b/app/models/project_role.rb
@@ -1,0 +1,6 @@
+class ProjectRole < ActiveRecord::Base
+  belongs_to :project, required: true
+  belongs_to :role, required: true
+
+  validates :project_id, uniqueness: { scope: :role_id }
+end

--- a/app/policies/project_role_policy.rb
+++ b/app/policies/project_role_policy.rb
@@ -1,0 +1,47 @@
+class ProjectRolePolicy
+  attr_reader :user, :project_role
+
+  def initialize(user, project_role)
+    @user = user
+    @project_role = project_role
+  end
+
+  def create?
+    return unless user.present?
+    return true if user.admin?
+    return true if current_user_is_at_least_admin_in_organization?
+  end
+
+  def destroy?
+    return unless user.present?
+    return true if user.admin?
+    return true if current_user_is_at_least_admin_in_organization?
+  end
+
+  private
+
+    def organization
+      @organization ||=
+        Organization.find(project_role.project.organization_id)
+    end
+
+    def organization_member_for_user
+      @organization_member_for_user ||=
+        OrganizationMembership.find_by(
+          member: user, organization: organization
+        )
+    end
+
+    def current_user_is_at_least_contributor_to_organization?
+      return false unless organization_member_for_user
+      return true if organization_member_for_user.contributor? ||
+                     organization_member_for_user.admin? ||
+                     organization_member_for_user.owner?
+    end
+
+    def current_user_is_at_least_admin_in_organization?
+      return false unless organization_member_for_user
+      return true if organization_member_for_user.admin? ||
+                     organization_member_for_user.owner?
+    end
+end

--- a/app/serializers/project_role_serializer.rb
+++ b/app/serializers/project_role_serializer.rb
@@ -1,4 +1,4 @@
 class ProjectRoleSerializer < ActiveModel::Serializer
   belongs_to :project, serializer: ProjectSerializerWithoutIncludes
-  belongs_to :role
+  belongs_to :role, serializer: RoleSerializerWithoutIncludes
 end

--- a/app/serializers/project_role_serializer.rb
+++ b/app/serializers/project_role_serializer.rb
@@ -1,0 +1,4 @@
+class ProjectRoleSerializer < ActiveModel::Serializer
+  belongs_to :project, serializer: ProjectSerializerWithoutIncludes
+  belongs_to :role
+end

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -21,6 +21,7 @@ class ProjectSerializer < ActiveModel::Serializer
 
   has_many :categories
   has_many :github_repositories
+  has_many :roles
 
   belongs_to :organization
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
       resources :posts, only: [:index, :show]
     end
     resources :project_categories, only: [:create, :destroy]
+    resources :project_roles, only: [:create, :destroy]
 
     resources :roles, only: [:index, :create]
     resources :role_skills, only: [:create]

--- a/db/migrate/20160520222346_create_project_roles.rb
+++ b/db/migrate/20160520222346_create_project_roles.rb
@@ -1,0 +1,14 @@
+class CreateProjectRoles < ActiveRecord::Migration
+  def change
+    create_table :project_roles do |t|
+      t.belongs_to :project
+      t.belongs_to :role
+
+      t.timestamps null: false
+    end
+
+    add_index :project_roles, [:project_id, :role_id], unique: true
+    add_foreign_key :project_roles, :projects, on_delete: :cascade
+    add_foreign_key :project_roles, :roles, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160520040950) do
+ActiveRecord::Schema.define(version: 20160520222346) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -206,6 +206,15 @@ ActiveRecord::Schema.define(version: 20160520040950) do
 
   add_index "project_categories", ["project_id", "category_id"], name: "index_project_categories_on_project_id_and_category_id", unique: true, using: :btree
 
+  create_table "project_roles", force: :cascade do |t|
+    t.integer  "project_id"
+    t.integer  "role_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "project_roles", ["project_id", "role_id"], name: "index_project_roles_on_project_id_and_role_id", unique: true, using: :btree
+
   create_table "projects", force: :cascade do |t|
     t.string   "title",             null: false
     t.string   "description"
@@ -309,5 +318,7 @@ ActiveRecord::Schema.define(version: 20160520040950) do
   add_foreign_key "posts", "users"
   add_foreign_key "project_categories", "categories", on_delete: :cascade
   add_foreign_key "project_categories", "projects", on_delete: :cascade
+  add_foreign_key "project_roles", "projects", on_delete: :cascade
+  add_foreign_key "project_roles", "roles", on_delete: :cascade
   add_foreign_key "projects", "organizations"
 end

--- a/spec/factories/project_role.rb
+++ b/spec/factories/project_role.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :project_role do
+    association :project
+    association :role
+  end
+end

--- a/spec/models/project_role_spec.rb
+++ b/spec/models/project_role_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe ProjectRole, type: :model do
+  describe "schema" do
+    it { should have_db_column(:project_id).of_type(:integer) }
+    it { should have_db_column(:role_id).of_type(:integer) }
+  end
+
+  describe "relationships" do
+    it { should belong_to(:project) }
+    it { should belong_to(:role) }
+  end
+
+  describe "validations" do
+    it { should validate_presence_of :project }
+    it { should validate_presence_of :role }
+
+    describe "uniquness" do
+      subject { create(:project_role) }
+
+      it { should validate_uniqueness_of(:project_id).scoped_to(:role_id) }
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -32,6 +32,8 @@ describe Project, type: :model do
     it { should belong_to(:organization) }
     it { should have_many(:project_categories) }
     it { should have_many(:categories).through(:project_categories) }
+    it { should have_many(:project_roles) }
+    it { should have_many(:roles).through(:project_roles) }
     it { should have_many(:github_repositories) }
     it { should have_many(:posts) }
   end

--- a/spec/policies/project_role_policy_spec.rb
+++ b/spec/policies/project_role_policy_spec.rb
@@ -1,0 +1,117 @@
+require "rails_helper"
+
+describe ProjectRolePolicy do
+  subject { described_class }
+
+  before do
+    @organization = create(:organization)
+    @unaffiliated_organization = create(:organization)
+
+    @project = create(:project, organization: @organization)
+    @unaffiliated_project = create(:project, organization: @unaffiliated_organization)
+
+    @unaffiliated_user = create(:user)
+
+    # Pending organization member
+    @pending_user = create(:user)
+    create(:organization_membership,
+           organization: @organization,
+           member: @pending_user,
+           role: "pending")
+
+    # Contributor organization member
+    @contributor_user = create(:user)
+    create(:organization_membership,
+           organization: @organization,
+           member: @contributor_user,
+           role: "contributor")
+
+    # Admin organization member
+    @admin_user = create(:user)
+    create(:organization_membership,
+           organization: @organization,
+           member: @admin_user,
+           role: "admin")
+
+    # Owner organization member
+    @owner_user = create(:user)
+    create(:organization_membership,
+           organization: @organization,
+           member: @owner_user,
+           role: "owner")
+
+    @project_role = create(:project_role, project: @project)
+
+    @unaffiliated_project_role = create(:project_role, project: @unaffiliated_project)
+
+    @site_admin = create(:user, admin: true)
+  end
+
+  permissions :create?, :destroy? do
+    context "as a logged out user" do
+      it "is not permitted" do
+        expect(subject).to_not permit(nil, create(:project))
+      end
+    end
+
+    context "as an unaffiliated user" do
+      it "is not permitted in other organizations" do
+        expect(subject).to_not permit(@unaffiliated_user, @unaffiliated_project_role)
+      end
+
+      it "is not permitted in their organization" do
+        expect(subject).to_not permit(@unaffiliated_user, @project_role)
+      end
+    end
+
+    context "as a pending user" do
+      it "is not permitted in other organizations" do
+        expect(subject).to_not permit(@pending_user, @unaffiliated_project_role)
+      end
+
+      it "is not permitted in their organization" do
+        expect(subject).to_not permit(@pending_user, @project_role)
+      end
+    end
+
+    context "as a contributor user" do
+      it "is not permitted in other organizations" do
+        expect(subject).to_not permit(@contributor_user, @unaffiliated_project_role)
+      end
+
+      it "is not permitted in their organization" do
+        expect(subject).to_not permit(@contributor_user, @project_role)
+      end
+    end
+
+    context "as an admin user" do
+      it "is not permitted in other organizations" do
+        expect(subject).to_not permit(@admin_user, @unaffiliated_project_role)
+      end
+
+      it "is permitted in their organization" do
+        expect(subject).to permit(@admin_user, @project_role)
+      end
+    end
+
+    context "as an owner user" do
+      it "is not permitted in other organizations" do
+        expect(subject).to_not permit(@owner_user, @unaffiliated_project_role)
+      end
+
+      it "is permitted in their organization" do
+        expect(subject).to permit(@owner_user, @project_role)
+      end
+    end
+
+    context "as a site admin" do
+      it "is permitted in other organizations" do
+        expect(subject).to permit(@site_admin, @unaffiliated_project_role)
+      end
+
+      it "is permitted in their organization" do
+        expect(subject).to permit(@site_admin, @project_role)
+      end
+    end
+  end
+end

--- a/spec/requests/api/project_roles_spec.rb
+++ b/spec/requests/api/project_roles_spec.rb
@@ -1,0 +1,188 @@
+require "rails_helper"
+
+describe "ProjectRoles API" do
+  describe "POST /project_roles" do
+    context "when unauthenticated" do
+      it "responds with a 401" do
+        post "#{host}/project_roles", data: {}
+        expect(last_response.status).to eq 401
+        expect(json).to be_a_valid_json_api_error.with_id "NOT_AUTHORIZED"
+      end
+    end
+
+    context "when authenticated" do
+      let(:token) { authenticate(email: "josh@coderly.com", password: "password") }
+
+      before do
+        @user = create(:user, email: "josh@coderly.com", password: "password")
+        organization = create(:organization)
+        @project = create(:project, organization: organization)
+        @role = create(:role)
+        create(:organization_membership, role: "admin", member: @user, organization: organization)
+      end
+
+      context "when creation is succesful" do
+        before do
+          authenticated_post "/project_roles", { data: { relationships: {
+            project: {
+              data: {
+                type: "projects", id: @project.id
+              }
+            },
+            role: {
+              data: {
+                type: "roles", id: @role.id
+              }
+            }
+          } } }, token
+        end
+
+        it "responds with the created project_role" do
+          expect(last_response.status).to eq 200
+        end
+
+        it "sets role to current role" do
+          expect(json.data.relationships.role.data.id).to eq @role.id.to_s
+          expect(ProjectRole.last.role).to eq @role
+        end
+
+        it "sets project to provided project" do
+          expect(json.data.relationships.project.data.id).to eq @project.id.to_s
+          expect(ProjectRole.last.project).to eq @project
+        end
+
+        it "includes role in the response" do
+          expect(json.included).not_to be_nil
+
+          included_roles = json.included.select { |i| i.type == "roles" }
+          expect(included_roles.count).to eq 1
+        end
+
+        it "includes project in the response" do
+          expect(json.included).not_to be_nil
+
+          included_roles = json.included.select { |i| i.type == "projects" }
+          expect(included_roles.count).to eq 1
+        end
+      end
+
+      context "when that project_role already exists" do
+        before do
+          create(:project_role, role: @role, project: @project)
+          authenticated_post "/project_roles", { data: { relationships: {
+            project: {
+              data: {
+                type: "projects", id: @project.id
+              }
+            },
+            role: {
+              data: {
+                type: "roles", id: @role.id
+              }
+            }
+          } } }, token
+        end
+
+        it "fails with a validation error" do
+          expect(last_response.status).to eq 422
+          expect(json).to be_a_valid_json_api_error.with_id "VALIDATION_ERROR"
+        end
+      end
+
+      context "when there's no project with the specified id" do
+        it "fails with a validation error" do
+          authenticated_post "/project_roles", { data: { relationships: {
+            project: { data: { type: "projects", id: 55 } },
+            role: {
+              data: {
+                type: "roles", id: @role.id
+              }
+            }
+          } } }, token
+
+          expect(last_response.status).to eq 422
+          expect(json).to be_a_valid_json_api_error.with_id "VALIDATION_ERROR"
+        end
+      end
+
+      it "requires a role to be specified" do
+        authenticated_post "/project_roles", { data: { relationships: {} } }, token
+        expect(last_response.status).to eq 400
+        expect(json).to be_a_valid_json_api_error.with_id "PARAMETER_MISSING"
+      end
+
+      it "requires a project to be specified" do
+        authenticated_post "/project_roles", { data: { relationships: {
+          role: {
+            data: {
+              type: "roles", id: @role.id
+            }
+          }
+        } } }, token
+        expect(last_response.status).to eq 400
+        expect(json).to be_a_valid_json_api_error.with_id "PARAMETER_MISSING"
+      end
+    end
+  end
+
+  describe "DELETE /project_roles/:id" do
+    context "when unauthenticated" do
+      it "responds with a 401" do
+        delete "#{host}/project_roles/1"
+
+        expect(last_response.status).to eq 401
+        expect(json).to be_a_valid_json_api_error.with_id "NOT_AUTHORIZED"
+      end
+    end
+
+    context "when authenticated" do
+      let(:token) { authenticate(email: "josh@coderly.com", password: "password") }
+
+      before do
+        @user = create(:user, email: "josh@coderly.com", password: "password")
+        organization = create(:organization)
+        @project = create(:project, organization: organization)
+        @role = create(:role)
+        create(:organization_membership, role: "admin", member: @user, organization: organization)
+      end
+
+      context "without admin access" do
+        before do
+          @user = create(:user, email: "random@user.com", password: "password")
+        end
+
+        let(:token) { authenticate(email: "random@user.com", password: "password") }
+
+        it "returns a 401 access denied" do
+          create(:project_role, id: 1, role: @role, project: @project)
+
+          authenticated_delete "/project_roles/1", {}, token
+
+          expect(last_response.status).to eq 401
+          expect(json).to be_a_valid_json_api_error.with_id "ACCESS_DENIED"
+          expect(ProjectRole.count).to eq 1
+        end
+      end
+
+      context "when deletion is successful" do
+        before do
+          create(:project_role, id: 1, role: @role, project: @project)
+          authenticated_delete "/project_roles/1", {}, token
+        end
+
+        it "responds with a 204" do
+          expect(last_response.status).to eq 204
+        end
+
+        it "deletes the project_role" do
+          expect(ProjectRole.count).to eq 0
+        end
+
+        it "leaves role and project untouched" do
+          expect(Role.count).to eq 1
+          expect(Project.count).to eq 1
+        end
+      end
+    end
+  end
+end

--- a/spec/serializers/project_role_serializer_spec.rb
+++ b/spec/serializers/project_role_serializer_spec.rb
@@ -1,0 +1,92 @@
+require "rails_helper"
+
+describe ProjectRoleSerializer, type: :serializer do
+  context "individual resource representation" do
+    let(:resource) { create(:project_role) }
+
+    let(:serializer) { ProjectRoleSerializer.new(resource) }
+    let(:serialization) { ActiveModel::Serializer::Adapter.create(serializer) }
+
+    context "root" do
+      subject do
+        JSON.parse(serialization.to_json)["data"]
+      end
+
+      it "doesn't have an attributes object" do
+        expect(subject["attributes"]).to be_nil
+      end
+
+      it "has a relationships object" do
+        expect(subject["relationships"]).not_to be_nil
+      end
+
+      it "has an id" do
+        expect(subject["id"]).not_to be_nil
+      end
+
+      it "has a type set to 'project_roles'" do
+        expect(subject["type"]).to eq "project_roles"
+      end
+    end
+
+    context "relationships" do
+      subject do
+        JSON.parse(serialization.to_json)["data"]["relationships"]
+      end
+
+      it "should contain a 'project' relationship" do
+        expect(subject["project"]).not_to be_nil
+        expect(subject["project"]["data"]["type"]).to eq "projects"
+        expect(subject["project"]["data"]["id"]).to eq resource.project.id.to_s
+      end
+
+      it "should contain a 'role' relationship" do
+        expect(subject["role"]).not_to be_nil
+        expect(subject["role"]["data"]["type"]).to eq "roles"
+        expect(subject["role"]["data"]["id"]).to eq resource.role.id.to_s
+      end
+    end
+
+    context "included" do
+      context "when not including anything" do
+        subject do
+          JSON.parse(serialization.to_json)["included"]
+        end
+
+        it "should be empty" do
+          expect(subject).to be_nil
+        end
+      end
+
+      context "when including 'project'" do
+        let(:serialization) do
+          ActiveModel::Serializer::Adapter.create(serializer, include: ["project"])
+        end
+
+        subject do
+          JSON.parse(serialization.to_json)["included"]
+        end
+
+        it "should not be empty" do
+          expect(subject).not_to be_nil
+          expect(subject.select { |i| i["type"] == "projects" }.length).to eq 1
+        end
+      end
+
+      context "when including 'role'" do
+        let(:serialization) do
+          ActiveModel::Serializer::Adapter.create(serializer, include: ["role"])
+        end
+
+        subject do
+          JSON.parse(serialization.to_json)["included"]
+        end
+
+        it "should not be empty" do
+          expect(subject).not_to be_nil
+          expect(subject.select { |i| i["type"] == "roles" }.length).to eq 1
+        end
+      end
+    end
+  end
+end

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -23,6 +23,7 @@ describe ProjectSerializer, type: :serializer do
     let(:resource) do
       project = create(:project)
       create_list(:project_category, 10, project: project)
+      create_list(:project_role, 10, project: project)
       create_list(:github_repository, 10, project: project)
       project
     end
@@ -94,6 +95,12 @@ describe ProjectSerializer, type: :serializer do
         expect(subject["categories"]["data"].all? { |r| r["type"] == "categories" }).to be true
       end
 
+      it "should have a 'roles' relationship" do
+        expect(subject["roles"]).not_to be_nil
+        expect(subject["roles"]["data"].length).to eq 10
+        expect(subject["roles"]["data"].all? { |r| r["type"] == "roles" }).to be true
+      end
+
       it "should have a 'github_repositories' relationship" do
         expect(subject["github_repositories"]).not_to be_nil
         expect(subject["github_repositories"]["data"].length).to eq 10
@@ -122,9 +129,24 @@ describe ProjectSerializer, type: :serializer do
         JSON.parse(serialization.to_json)["included"]
       end
 
-      it "should contain the user's categories" do
+      it "should contain the project's categories" do
         expect(subject).not_to be_nil
         expect(subject.select { |i| i["type"] == "categories" }.length).to eq 10
+      end
+    end
+
+    context "when including roles" do
+      let(:serialization) do
+        ActiveModel::Serializer::Adapter.create(serializer, include: ["roles"])
+      end
+
+      subject do
+        JSON.parse(serialization.to_json)["included"]
+      end
+
+      it "should contain the project's roles" do
+        expect(subject).not_to be_nil
+        expect(subject.select { |i| i["type"] == "roles" }.length).to eq 10
       end
     end
 
@@ -137,7 +159,7 @@ describe ProjectSerializer, type: :serializer do
         JSON.parse(serialization.to_json)["included"]
       end
 
-      it "should contain the user's github_repositories" do
+      it "should contain the project's github_repositories" do
         expect(subject).not_to be_nil
         expect(subject.select { |i| i["type"] == "github_repositories" }.length).to eq 10
       end


### PR DESCRIPTION
Closes #270.
- [x] Add `ProjectRole` model and specs
- [x] Add `ProjectRolePolicy` and specs
- [x] Add to `Project` as `has_many`
- [x] Add to `ProjectSerializer` and specs
- [x] Add `ProjectRoleSerialize` and specs
- [x] Add project role API specs, controller, routes, etc.
