### PR TITLE
Add ProjectSkill

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: categories
+#
+#  id          :integer          not null, primary key
+#  name        :string           not null
+#  slug        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  description :text
+#
+
 class CategoriesController < ApplicationController
   before_action :doorkeeper_authorize!, only: [:create]
 

--- a/app/controllers/organization_memberships_controller.rb
+++ b/app/controllers/organization_memberships_controller.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: organization_memberships
+#
+#  id              :integer          not null, primary key
+#  role            :string           default("pending"), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  member_id       :integer
+#  organization_id :integer
+#
+
 class OrganizationMembershipsController < ApplicationController
   before_action :doorkeeper_authorize!, only: [:create, :update, :destroy]
 

--- a/app/controllers/project_categories_controller.rb
+++ b/app/controllers/project_categories_controller.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: project_categories
+#
+#  id          :integer          not null, primary key
+#  project_id  :integer
+#  category_id :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
 class ProjectCategoriesController < ApplicationController
   before_action :doorkeeper_authorize!
   before_action :require_params, only: [:create]

--- a/app/controllers/project_skills_controller.rb
+++ b/app/controllers/project_skills_controller.rb
@@ -16,15 +16,8 @@ class ProjectSkillsController < ApplicationController
   def create
     project_skill = ProjectSkill.new(create_params)
 
-    if project_skill.project.blank?
-      project_skill.valid?
-      render_validation_errors project_skill.errors
-      return
-    end
-
-    authorize project_skill
-
     if project_skill.valid?
+      authorize project_skill
       project_skill.save!
       render json: project_skill, include: [:skill, :project]
     else

--- a/app/controllers/project_skills_controller.rb
+++ b/app/controllers/project_skills_controller.rb
@@ -1,0 +1,44 @@
+class ProjectSkillsController < ApplicationController
+  before_action :doorkeeper_authorize!
+  before_action :require_params, only: [:create]
+
+  def create
+    project_skill = ProjectSkill.new(create_params)
+
+    if project_skill.project.blank?
+      project_skill.valid?
+      render_validation_errors project_skill.errors
+      return
+    end
+
+    authorize project_skill
+
+    if project_skill.valid?
+      project_skill.save!
+      render json: project_skill, include: [:skill, :project]
+    else
+      render_validation_errors project_skill.errors
+    end
+  end
+
+  def destroy
+    project_skill = ProjectSkill.find(params[:id])
+
+    authorize project_skill
+
+    project_skill.destroy!
+
+    render json: :nothing, status: :no_content
+  end
+
+  private
+
+    def require_params
+      require_param :skill_id
+      require_param :project_id
+    end
+
+    def create_params
+      parse_params(params)
+    end
+end

--- a/app/controllers/project_skills_controller.rb
+++ b/app/controllers/project_skills_controller.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: project_skills
+#
+#  id         :integer          not null, primary key
+#  project_id :integer
+#  skill_id   :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 class ProjectSkillsController < ApplicationController
   before_action :doorkeeper_authorize!
   before_action :require_params, only: [:create]

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -26,7 +26,7 @@ class ProjectsController < ApplicationController
       projects = find_projects_with_slugged_route!
     else
       projects = Project.all.includes(
-        :categories, :github_repositories, :organization,
+        :categories, :github_repositories, :organization, :skills
       )
     end
 
@@ -101,7 +101,7 @@ class ProjectsController < ApplicationController
 
     def find_project_with_slugged_route!
       slugged_route = find_slugged_route!
-      Project.includes(:categories, :github_repositories, :organization).
+      Project.includes(:categories, :github_repositories, :organization, :skills).
         where("lower(slug) = ?", project_slug.downcase).
         find_by!(organization: slugged_route.owner)
     end
@@ -109,7 +109,7 @@ class ProjectsController < ApplicationController
     def find_projects_with_slugged_route!
       slugged_route = find_slugged_route!
       Project.
-        includes(:categories, :github_repositories, :organization).
+        includes(:categories, :github_repositories, :organization, :skills).
         where(organization: slugged_route.owner)
     end
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: categories
+#
+#  id          :integer          not null, primary key
+#  name        :string           not null
+#  slug        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  description :text
+#
+
 class Category < ActiveRecord::Base
   has_many :project_categories
   has_many :projects, through: :project_categories

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -23,6 +23,8 @@ class Project < ActiveRecord::Base
 
   has_many :project_categories
   has_many :categories, through: :project_categories
+  has_many :project_skills
+  has_many :skills, through: :project_skills
   has_many :github_repositories
   has_many :posts
 

--- a/app/models/project_category.rb
+++ b/app/models/project_category.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: project_categories
+#
+#  id          :integer          not null, primary key
+#  project_id  :integer
+#  category_id :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
 class ProjectCategory < ActiveRecord::Base
   belongs_to :project, required: true
   belongs_to :category, required: true

--- a/app/models/project_skill.rb
+++ b/app/models/project_skill.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: project_skills
+#
+#  id         :integer          not null, primary key
+#  project_id :integer
+#  skill_id   :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 class ProjectSkill < ActiveRecord::Base
   belongs_to :project, required: true
   belongs_to :skill, required: true

--- a/app/models/project_skill.rb
+++ b/app/models/project_skill.rb
@@ -1,0 +1,6 @@
+class ProjectSkill < ActiveRecord::Base
+  belongs_to :project, required: true
+  belongs_to :skill, required: true
+
+  validates :project_id, uniqueness: { scope: :skill_id }
+end

--- a/app/policies/project_skill_policy.rb
+++ b/app/policies/project_skill_policy.rb
@@ -1,0 +1,47 @@
+class ProjectSkillPolicy
+  attr_reader :user, :project_skill
+
+  def initialize(user, project_skill)
+    @user = user
+    @project_skill = project_skill
+  end
+
+  def create?
+    return unless user.present?
+    return true if user.admin?
+    return true if current_user_is_at_least_admin_in_organization?
+  end
+
+  def destroy?
+    return unless user.present?
+    return true if user.admin?
+    return true if current_user_is_at_least_admin_in_organization?
+  end
+
+  private
+
+    def organization
+      @organization ||=
+        Organization.find(project_skill.project.organization_id)
+    end
+
+    def organization_member_for_user
+      @organization_member_for_user ||=
+        OrganizationMembership.find_by(
+          member: user, organization: organization
+        )
+    end
+
+    def current_user_is_at_least_contributor_to_organization?
+      return false unless organization_member_for_user
+      return true if organization_member_for_user.contributor? ||
+                     organization_member_for_user.admin? ||
+                     organization_member_for_user.owner?
+    end
+
+    def current_user_is_at_least_admin_in_organization?
+      return false unless organization_member_for_user
+      return true if organization_member_for_user.admin? ||
+                     organization_member_for_user.owner?
+    end
+end

--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: categories
+#
+#  id          :integer          not null, primary key
+#  name        :string           not null
+#  slug        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  description :text
+#
+
 class CategorySerializer < ActiveModel::Serializer
   attributes :id, :name, :slug, :description
 end

--- a/app/serializers/organization_membership_serializer.rb
+++ b/app/serializers/organization_membership_serializer.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: organization_memberships
+#
+#  id              :integer          not null, primary key
+#  role            :string           default("pending"), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  member_id       :integer
+#  organization_id :integer
+#
+
 class OrganizationMembershipSerializer < ActiveModel::Serializer
   attributes :id, :role
 

--- a/app/serializers/project_category_serializer.rb
+++ b/app/serializers/project_category_serializer.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: project_categories
+#
+#  id          :integer          not null, primary key
+#  project_id  :integer
+#  category_id :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
 class ProjectCategorySerializer < ActiveModel::Serializer
   belongs_to :project, serializer: ProjectSerializerWithoutIncludes
   belongs_to :category

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -21,6 +21,7 @@ class ProjectSerializer < ActiveModel::Serializer
 
   has_many :categories
   has_many :github_repositories
+  has_many :skills
 
   belongs_to :organization
 

--- a/app/serializers/project_skill_serializer.rb
+++ b/app/serializers/project_skill_serializer.rb
@@ -1,0 +1,4 @@
+class ProjectSkillSerializer < ActiveModel::Serializer
+  belongs_to :project, serializer: ProjectSerializerWithoutIncludes
+  belongs_to :skill, serializer: SkillSerializerWithoutIncludes
+end

--- a/app/serializers/project_skill_serializer.rb
+++ b/app/serializers/project_skill_serializer.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: project_skills
+#
+#  id         :integer          not null, primary key
+#  project_id :integer
+#  skill_id   :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 class ProjectSkillSerializer < ActiveModel::Serializer
   belongs_to :project, serializer: ProjectSerializerWithoutIncludes
   belongs_to :skill, serializer: SkillSerializerWithoutIncludes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
       resources :posts, only: [:index, :show]
     end
     resources :project_categories, only: [:create, :destroy]
+    resources :project_skills, only: [:create, :destroy]
 
     resources :roles, only: [:index, :create]
     resources :role_skills, only: [:create]

--- a/db/migrate/20160520231546_create_project_skills.rb
+++ b/db/migrate/20160520231546_create_project_skills.rb
@@ -1,0 +1,14 @@
+class CreateProjectSkills < ActiveRecord::Migration
+  def change
+    create_table :project_skills do |t|
+      t.belongs_to :project
+      t.belongs_to :skill
+
+      t.timestamps null: false
+    end
+
+    add_index :project_skills, [:project_id, :skill_id], unique: true
+    add_foreign_key :project_skills, :projects, on_delete: :cascade
+    add_foreign_key :project_skills, :skills, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160520040950) do
+ActiveRecord::Schema.define(version: 20160520231546) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -206,6 +206,24 @@ ActiveRecord::Schema.define(version: 20160520040950) do
 
   add_index "project_categories", ["project_id", "category_id"], name: "index_project_categories_on_project_id_and_category_id", unique: true, using: :btree
 
+  create_table "project_roles", force: :cascade do |t|
+    t.integer  "project_id"
+    t.integer  "role_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "project_roles", ["project_id", "role_id"], name: "index_project_roles_on_project_id_and_role_id", unique: true, using: :btree
+
+  create_table "project_skills", force: :cascade do |t|
+    t.integer  "project_id"
+    t.integer  "skill_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "project_skills", ["project_id", "skill_id"], name: "index_project_skills_on_project_id_and_skill_id", unique: true, using: :btree
+
   create_table "projects", force: :cascade do |t|
     t.string   "title",             null: false
     t.string   "description"
@@ -309,5 +327,9 @@ ActiveRecord::Schema.define(version: 20160520040950) do
   add_foreign_key "posts", "users"
   add_foreign_key "project_categories", "categories", on_delete: :cascade
   add_foreign_key "project_categories", "projects", on_delete: :cascade
+  add_foreign_key "project_roles", "projects", on_delete: :cascade
+  add_foreign_key "project_roles", "roles", on_delete: :cascade
+  add_foreign_key "project_skills", "projects", on_delete: :cascade
+  add_foreign_key "project_skills", "skills", on_delete: :cascade
   add_foreign_key "projects", "organizations"
 end

--- a/spec/factories/category_factory.rb
+++ b/spec/factories/category_factory.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: categories
+#
+#  id          :integer          not null, primary key
+#  name        :string           not null
+#  slug        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  description :text
+#
+
 FactoryGirl.define do
   factory :category do
     sequence(:name) { |n| "Category #{n}" }

--- a/spec/factories/project_category_factory.rb
+++ b/spec/factories/project_category_factory.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: project_categories
+#
+#  id          :integer          not null, primary key
+#  project_id  :integer
+#  category_id :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
 FactoryGirl.define do
   factory :project_category do
     association :project

--- a/spec/factories/project_skill_factory.rb
+++ b/spec/factories/project_skill_factory.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :project_skill do
+    association :project
+    association :skill
+  end
+end

--- a/spec/factories/project_skill_factory.rb
+++ b/spec/factories/project_skill_factory.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: project_skills
+#
+#  id         :integer          not null, primary key
+#  project_id :integer
+#  skill_id   :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 FactoryGirl.define do
   factory :project_skill do
     association :project

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: categories
+#
+#  id          :integer          not null, primary key
+#  name        :string           not null
+#  slug        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  description :text
+#
+
 require "rails_helper"
 
 RSpec.describe Category, type: :model do

--- a/spec/models/project_category_spec.rb
+++ b/spec/models/project_category_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: project_categories
+#
+#  id          :integer          not null, primary key
+#  project_id  :integer
+#  category_id :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
 require "rails_helper"
 
 RSpec.describe ProjectCategory, type: :model do

--- a/spec/models/project_skill_spec.rb
+++ b/spec/models/project_skill_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe ProjectSkill, type: :model do
+  describe "schema" do
+    it { should have_db_column(:project_id).of_type(:integer) }
+    it { should have_db_column(:skill_id).of_type(:integer) }
+  end
+
+  describe "relationships" do
+    it { should belong_to(:project) }
+    it { should belong_to(:skill) }
+  end
+
+  describe "validations" do
+    it { should validate_presence_of :project }
+    it { should validate_presence_of :skill }
+
+    describe "uniquness" do
+      subject { create(:project_skill) }
+
+      it { should validate_uniqueness_of(:project_id).scoped_to(:skill_id) }
+    end
+  end
+end

--- a/spec/models/project_skill_spec.rb
+++ b/spec/models/project_skill_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: project_skills
+#
+#  id         :integer          not null, primary key
+#  project_id :integer
+#  skill_id   :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 require "rails_helper"
 
 RSpec.describe ProjectSkill, type: :model do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -32,6 +32,8 @@ describe Project, type: :model do
     it { should belong_to(:organization) }
     it { should have_many(:project_categories) }
     it { should have_many(:categories).through(:project_categories) }
+    it { should have_many(:project_skills) }
+    it { should have_many(:skills).through(:project_skills) }
     it { should have_many(:github_repositories) }
     it { should have_many(:posts) }
   end

--- a/spec/policies/project_skill_policy_spec.rb
+++ b/spec/policies/project_skill_policy_spec.rb
@@ -1,0 +1,117 @@
+require "rails_helper"
+
+describe ProjectSkillPolicy do
+  subject { described_class }
+
+  before do
+    @organization = create(:organization)
+    @unaffiliated_organization = create(:organization)
+
+    @project = create(:project, organization: @organization)
+    @unaffiliated_project = create(:project, organization: @unaffiliated_organization)
+
+    @unaffiliated_user = create(:user)
+
+    # Pending organization member
+    @pending_user = create(:user)
+    create(:organization_membership,
+           organization: @organization,
+           member: @pending_user,
+           role: "pending")
+
+    # Contributor organization member
+    @contributor_user = create(:user)
+    create(:organization_membership,
+           organization: @organization,
+           member: @contributor_user,
+           role: "contributor")
+
+    # Admin organization member
+    @admin_user = create(:user)
+    create(:organization_membership,
+           organization: @organization,
+           member: @admin_user,
+           role: "admin")
+
+    # Owner organization member
+    @owner_user = create(:user)
+    create(:organization_membership,
+           organization: @organization,
+           member: @owner_user,
+           role: "owner")
+
+    @project_skill = create(:project_skill, project: @project)
+
+    @unaffiliated_project_skill = create(:project_skill, project: @unaffiliated_project)
+
+    @site_admin = create(:user, admin: true)
+  end
+
+  permissions :create?, :destroy? do
+    context "as a logged out user" do
+      it "is not permitted" do
+        expect(subject).to_not permit(nil, create(:project))
+      end
+    end
+
+    context "as an unaffiliated user" do
+      it "is not permitted in other organizations" do
+        expect(subject).to_not permit(@unaffiliated_user, @unaffiliated_project_skill)
+      end
+
+      it "is not permitted in their organization" do
+        expect(subject).to_not permit(@unaffiliated_user, @project_skill)
+      end
+    end
+
+    context "as a pending user" do
+      it "is not permitted in other organizations" do
+        expect(subject).to_not permit(@pending_user, @unaffiliated_project_skill)
+      end
+
+      it "is not permitted in their organization" do
+        expect(subject).to_not permit(@pending_user, @project_skill)
+      end
+    end
+
+    context "as a contributor user" do
+      it "is not permitted in other organizations" do
+        expect(subject).to_not permit(@contributor_user, @unaffiliated_project_skill)
+      end
+
+      it "is not permitted in their organization" do
+        expect(subject).to_not permit(@contributor_user, @project_skill)
+      end
+    end
+
+    context "as an admin user" do
+      it "is not permitted in other organizations" do
+        expect(subject).to_not permit(@admin_user, @unaffiliated_project_skill)
+      end
+
+      it "is permitted in their organization" do
+        expect(subject).to permit(@admin_user, @project_skill)
+      end
+    end
+
+    context "as an owner user" do
+      it "is not permitted in other organizations" do
+        expect(subject).to_not permit(@owner_user, @unaffiliated_project_skill)
+      end
+
+      it "is permitted in their organization" do
+        expect(subject).to permit(@owner_user, @project_skill)
+      end
+    end
+
+    context "as a site admin" do
+      it "is permitted in other organizations" do
+        expect(subject).to permit(@site_admin, @unaffiliated_project_skill)
+      end
+
+      it "is permitted in their organization" do
+        expect(subject).to permit(@site_admin, @project_skill)
+      end
+    end
+  end
+end

--- a/spec/requests/api/project_skills_spec.rb
+++ b/spec/requests/api/project_skills_spec.rb
@@ -1,0 +1,188 @@
+require "rails_helper"
+
+describe "ProjectSkills API" do
+  describe "POST /project_skills" do
+    context "when unauthenticated" do
+      it "responds with a 401" do
+        post "#{host}/project_skills", data: {}
+        expect(last_response.status).to eq 401
+        expect(json).to be_a_valid_json_api_error.with_id "NOT_AUTHORIZED"
+      end
+    end
+
+    context "when authenticated" do
+      let(:token) { authenticate(email: "josh@coderly.com", password: "password") }
+
+      before do
+        @user = create(:user, email: "josh@coderly.com", password: "password")
+        organization = create(:organization)
+        @project = create(:project, organization: organization)
+        @skill = create(:skill)
+        create(:organization_membership, role: "admin", member: @user, organization: organization)
+      end
+
+      context "when creation is succesful" do
+        before do
+          authenticated_post "/project_skills", { data: { relationships: {
+            project: {
+              data: {
+                type: "projects", id: @project.id
+              }
+            },
+            skill: {
+              data: {
+                type: "skills", id: @skill.id
+              }
+            }
+          } } }, token
+        end
+
+        it "responds with the created project_skill" do
+          expect(last_response.status).to eq 200
+        end
+
+        it "sets skill to current skill" do
+          expect(json.data.relationships.skill.data.id).to eq @skill.id.to_s
+          expect(ProjectSkill.last.skill).to eq @skill
+        end
+
+        it "sets project to provided project" do
+          expect(json.data.relationships.project.data.id).to eq @project.id.to_s
+          expect(ProjectSkill.last.project).to eq @project
+        end
+
+        it "includes skill in the response" do
+          expect(json.included).not_to be_nil
+
+          included_skills = json.included.select { |i| i.type == "skills" }
+          expect(included_skills.count).to eq 1
+        end
+
+        it "includes project in the response" do
+          expect(json.included).not_to be_nil
+
+          included_skills = json.included.select { |i| i.type == "projects" }
+          expect(included_skills.count).to eq 1
+        end
+      end
+
+      context "when that project_skill already exists" do
+        before do
+          create(:project_skill, skill: @skill, project: @project)
+          authenticated_post "/project_skills", { data: { relationships: {
+            project: {
+              data: {
+                type: "projects", id: @project.id
+              }
+            },
+            skill: {
+              data: {
+                type: "skills", id: @skill.id
+              }
+            }
+          } } }, token
+        end
+
+        it "fails with a validation error" do
+          expect(last_response.status).to eq 422
+          expect(json).to be_a_valid_json_api_error.with_id "VALIDATION_ERROR"
+        end
+      end
+
+      context "when there's no project with the specified id" do
+        it "fails with a validation error" do
+          authenticated_post "/project_skills", { data: { relationships: {
+            project: { data: { type: "projects", id: 55 } },
+            skill: {
+              data: {
+                type: "skills", id: @skill.id
+              }
+            }
+          } } }, token
+
+          expect(last_response.status).to eq 422
+          expect(json).to be_a_valid_json_api_error.with_id "VALIDATION_ERROR"
+        end
+      end
+
+      it "requires a skill to be specified" do
+        authenticated_post "/project_skills", { data: { relationships: {} } }, token
+        expect(last_response.status).to eq 400
+        expect(json).to be_a_valid_json_api_error.with_id "PARAMETER_MISSING"
+      end
+
+      it "requires a project to be specified" do
+        authenticated_post "/project_skills", { data: { relationships: {
+          skill: {
+            data: {
+              type: "skills", id: @skill.id
+            }
+          }
+        } } }, token
+        expect(last_response.status).to eq 400
+        expect(json).to be_a_valid_json_api_error.with_id "PARAMETER_MISSING"
+      end
+    end
+  end
+
+  describe "DELETE /project_skills/:id" do
+    context "when unauthenticated" do
+      it "responds with a 401" do
+        delete "#{host}/project_skills/1"
+
+        expect(last_response.status).to eq 401
+        expect(json).to be_a_valid_json_api_error.with_id "NOT_AUTHORIZED"
+      end
+    end
+
+    context "when authenticated" do
+      let(:token) { authenticate(email: "josh@coderly.com", password: "password") }
+
+      before do
+        @user = create(:user, email: "josh@coderly.com", password: "password")
+        organization = create(:organization)
+        @project = create(:project, organization: organization)
+        @skill = create(:skill)
+        create(:organization_membership, role: "admin", member: @user, organization: organization)
+      end
+
+      context "without admin access" do
+        before do
+          @user = create(:user, email: "random@user.com", password: "password")
+        end
+
+        let(:token) { authenticate(email: "random@user.com", password: "password") }
+
+        it "returns a 401 access denied" do
+          create(:project_skill, id: 1, skill: @skill, project: @project)
+
+          authenticated_delete "/project_skills/1", {}, token
+
+          expect(last_response.status).to eq 401
+          expect(json).to be_a_valid_json_api_error.with_id "ACCESS_DENIED"
+          expect(ProjectSkill.count).to eq 1
+        end
+      end
+
+      context "when deletion is successful" do
+        before do
+          create(:project_skill, id: 1, skill: @skill, project: @project)
+          authenticated_delete "/project_skills/1", {}, token
+        end
+
+        it "responds with a 204" do
+          expect(last_response.status).to eq 204
+        end
+
+        it "deletes the project_skill" do
+          expect(ProjectSkill.count).to eq 0
+        end
+
+        it "leaves skill and project untouched" do
+          expect(Skill.count).to eq 1
+          expect(Project.count).to eq 1
+        end
+      end
+    end
+  end
+end

--- a/spec/serializers/category_serializer_spec.rb
+++ b/spec/serializers/category_serializer_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: categories
+#
+#  id          :integer          not null, primary key
+#  name        :string           not null
+#  slug        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  description :text
+#
+
 require "rails_helper"
 
 describe CategorySerializer, type: :serializer do

--- a/spec/serializers/project_category_serializer_spec.rb
+++ b/spec/serializers/project_category_serializer_spec.rb
@@ -2,11 +2,11 @@
 #
 # Table name: project_categories
 #
-#  id         :integer          not null, primary key
-#  project_id    :integer
-#  category_id    :integer
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id          :integer          not null, primary key
+#  project_id  :integer
+#  category_id :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
 #
 
 require "rails_helper"

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -23,6 +23,7 @@ describe ProjectSerializer, type: :serializer do
     let(:resource) do
       project = create(:project)
       create_list(:project_category, 10, project: project)
+      create_list(:project_skill, 10, project: project)
       create_list(:github_repository, 10, project: project)
       project
     end
@@ -99,6 +100,12 @@ describe ProjectSerializer, type: :serializer do
         expect(subject["github_repositories"]["data"].length).to eq 10
         expect(subject["github_repositories"]["data"].all? { |r| r["type"] == "github_repositories" }).to be true
       end
+
+      it "should have a 'skills' relationship" do
+        expect(subject["skills"]).not_to be_nil
+        expect(subject["skills"]["data"].length).to eq 10
+        expect(subject["skills"]["data"].all? { |r| r["type"] == "skills" }).to be true
+      end
     end
 
     context "included" do
@@ -122,7 +129,7 @@ describe ProjectSerializer, type: :serializer do
         JSON.parse(serialization.to_json)["included"]
       end
 
-      it "should contain the user's categories" do
+      it "should contain the project's categories" do
         expect(subject).not_to be_nil
         expect(subject.select { |i| i["type"] == "categories" }.length).to eq 10
       end
@@ -137,9 +144,24 @@ describe ProjectSerializer, type: :serializer do
         JSON.parse(serialization.to_json)["included"]
       end
 
-      it "should contain the user's github_repositories" do
+      it "should contain the project's github_repositories" do
         expect(subject).not_to be_nil
         expect(subject.select { |i| i["type"] == "github_repositories" }.length).to eq 10
+      end
+    end
+
+    context "when including skills" do
+      let(:serialization) do
+        ActiveModel::Serializer::Adapter.create(serializer, include: ["skills"])
+      end
+
+      subject do
+        JSON.parse(serialization.to_json)["included"]
+      end
+
+      it "should contain the project's skills" do
+        expect(subject).not_to be_nil
+        expect(subject.select { |i| i["type"] == "skills" }.length).to eq 10
       end
     end
   end

--- a/spec/serializers/project_skill_serializer_spec.rb
+++ b/spec/serializers/project_skill_serializer_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: project_skills
+#
+#  id         :integer          not null, primary key
+#  project_id :integer
+#  skill_id   :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 require "rails_helper"
 
 describe ProjectSkillSerializer, type: :serializer do

--- a/spec/serializers/project_skill_serializer_spec.rb
+++ b/spec/serializers/project_skill_serializer_spec.rb
@@ -1,0 +1,92 @@
+require "rails_helper"
+
+describe ProjectSkillSerializer, type: :serializer do
+  context "individual resource representation" do
+    let(:resource) { create(:project_skill) }
+
+    let(:serializer) { ProjectSkillSerializer.new(resource) }
+    let(:serialization) { ActiveModel::Serializer::Adapter.create(serializer) }
+
+    context "root" do
+      subject do
+        JSON.parse(serialization.to_json)["data"]
+      end
+
+      it "doesn't have an attributes object" do
+        expect(subject["attributes"]).to be_nil
+      end
+
+      it "has a relationships object" do
+        expect(subject["relationships"]).not_to be_nil
+      end
+
+      it "has an id" do
+        expect(subject["id"]).not_to be_nil
+      end
+
+      it "has a type set to 'project_skills'" do
+        expect(subject["type"]).to eq "project_skills"
+      end
+    end
+
+    context "relationships" do
+      subject do
+        JSON.parse(serialization.to_json)["data"]["relationships"]
+      end
+
+      it "should contain a 'project' relationship" do
+        expect(subject["project"]).not_to be_nil
+        expect(subject["project"]["data"]["type"]).to eq "projects"
+        expect(subject["project"]["data"]["id"]).to eq resource.project.id.to_s
+      end
+
+      it "should contain a 'skill' relationship" do
+        expect(subject["skill"]).not_to be_nil
+        expect(subject["skill"]["data"]["type"]).to eq "skills"
+        expect(subject["skill"]["data"]["id"]).to eq resource.skill.id.to_s
+      end
+    end
+
+    context "included" do
+      context "when not including anything" do
+        subject do
+          JSON.parse(serialization.to_json)["included"]
+        end
+
+        it "should be empty" do
+          expect(subject).to be_nil
+        end
+      end
+
+      context "when including 'project'" do
+        let(:serialization) do
+          ActiveModel::Serializer::Adapter.create(serializer, include: ["project"])
+        end
+
+        subject do
+          JSON.parse(serialization.to_json)["included"]
+        end
+
+        it "should not be empty" do
+          expect(subject).not_to be_nil
+          expect(subject.select { |i| i["type"] == "projects" }.length).to eq 1
+        end
+      end
+
+      context "when including 'skill'" do
+        let(:serialization) do
+          ActiveModel::Serializer::Adapter.create(serializer, include: ["skill"])
+        end
+
+        subject do
+          JSON.parse(serialization.to_json)["included"]
+        end
+
+        it "should not be empty" do
+          expect(subject).not_to be_nil
+          expect(subject.select { |i| i["type"] == "skills" }.length).to eq 1
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #271.
- [x] Add `ProjectSkill` model and specs
- [x] Add `ProjectSkillPolicy` and specs
- [x] Add to `Project` as `has_many`
- [x] Add to `ProjectSerializer` and specs
- [x] Add `ProjectSkillSerializer` and specs
- [x] Add project skill API specs, controller, routes, etc.
