### PR TITLE
Add project visibility and publishing

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -25,7 +25,7 @@ class ProjectsController < ApplicationController
     if for_slugged_route?
       projects = find_projects_with_slugged_route!
     else
-      projects = Project.all.includes(
+      projects = Project.published.includes(
         :categories, :github_repositories, :organization,
       )
     end
@@ -115,6 +115,7 @@ class ProjectsController < ApplicationController
     def find_projects_with_slugged_route!
       slugged_route = find_slugged_route!
       Project.
+        published.
         includes(:categories, :github_repositories, :organization).
         where(organization: slugged_route.owner)
     end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -50,7 +50,7 @@ class ProjectsController < ApplicationController
 
     authorize project
 
-    if project.save
+    if project.update(publish?)
       AddProjectIconWorker.perform_async(project.id)
       render json: project
     else
@@ -63,9 +63,9 @@ class ProjectsController < ApplicationController
 
     authorize project
 
-    project.update(update_params)
+    project.assign_attributes(update_params)
 
-    if project.save
+    if project.update(publish?)
       AddProjectIconWorker.perform_async(project.id)
       render json: project
     else
@@ -74,6 +74,12 @@ class ProjectsController < ApplicationController
   end
 
   private
+
+    def publish?
+      ActiveRecord::Type::Boolean.new.type_cast_from_user(
+        parse_params(params).fetch(:publish, false)
+      )
+    end
 
     def create_params
       parse_params(params, only: [:base64_icon_data, :title, :description, :slug, :organization])

--- a/db/migrate/20160521011905_add_state_to_projects.rb
+++ b/db/migrate/20160521011905_add_state_to_projects.rb
@@ -1,0 +1,5 @@
+class AddStateToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :aasm_state, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160520040950) do
+ActiveRecord::Schema.define(version: 20160521011905) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -206,6 +206,24 @@ ActiveRecord::Schema.define(version: 20160520040950) do
 
   add_index "project_categories", ["project_id", "category_id"], name: "index_project_categories_on_project_id_and_category_id", unique: true, using: :btree
 
+  create_table "project_roles", force: :cascade do |t|
+    t.integer  "project_id"
+    t.integer  "role_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "project_roles", ["project_id", "role_id"], name: "index_project_roles_on_project_id_and_role_id", unique: true, using: :btree
+
+  create_table "project_skills", force: :cascade do |t|
+    t.integer  "project_id"
+    t.integer  "skill_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "project_skills", ["project_id", "skill_id"], name: "index_project_skills_on_project_id_and_skill_id", unique: true, using: :btree
+
   create_table "projects", force: :cascade do |t|
     t.string   "title",             null: false
     t.string   "description"
@@ -218,6 +236,7 @@ ActiveRecord::Schema.define(version: 20160520040950) do
     t.text     "base64_icon_data"
     t.string   "slug",              null: false
     t.integer  "organization_id",   null: false
+    t.string   "aasm_state"
   end
 
   add_index "projects", ["organization_id"], name: "index_projects_on_organization_id", using: :btree
@@ -253,6 +272,15 @@ ActiveRecord::Schema.define(version: 20160520040950) do
 
   add_index "slugged_routes", ["owner_id", "owner_type"], name: "index_slugged_routes_on_owner_id_and_owner_type", unique: true, using: :btree
   add_index "slugged_routes", ["slug"], name: "index_slugged_routes_on_slug", unique: true, using: :btree
+
+  create_table "user_categories", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "category_id"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
+
+  add_index "user_categories", ["user_id", "category_id"], name: "index_user_categories_on_user_id_and_category_id", unique: true, using: :btree
 
   create_table "user_relationships", force: :cascade do |t|
     t.integer  "follower_id"
@@ -309,5 +337,11 @@ ActiveRecord::Schema.define(version: 20160520040950) do
   add_foreign_key "posts", "users"
   add_foreign_key "project_categories", "categories", on_delete: :cascade
   add_foreign_key "project_categories", "projects", on_delete: :cascade
+  add_foreign_key "project_roles", "projects", on_delete: :cascade
+  add_foreign_key "project_roles", "roles", on_delete: :cascade
+  add_foreign_key "project_skills", "projects", on_delete: :cascade
+  add_foreign_key "project_skills", "skills", on_delete: :cascade
   add_foreign_key "projects", "organizations"
+  add_foreign_key "user_categories", "categories", on_delete: :cascade
+  add_foreign_key "user_categories", "users", on_delete: :cascade
 end

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -23,10 +23,16 @@ FactoryGirl.define do
 
     association :organization
 
+    trait :with_categories do
+      after(:build) do |project|
+        create(:project_category, project: project)
+      end
+    end
+
     trait :with_s3_icon do
-      after(:build) do |project, evaluator|
-        project.icon_file_name = 'project.jpg'
-        project.icon_content_type = 'image/jpeg'
+      after(:build) do |project|
+        project.icon_file_name = "project.jpg"
+        project.icon_content_type = "image/jpeg"
         project.icon_file_size = 1024
         project.icon_updated_at = Time.now
       end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -145,6 +145,18 @@ describe Project, type: :model do
     end
   end
 
+  context ".published" do
+    it "only returns published projects" do
+      published_project = create(:project, :with_categories)
+      published_project.update(true)
+      unpublished_project = create(:project)
+
+      published_projects = Project.published
+      expect(published_projects).to include published_project
+      expect(published_projects).not_to include unpublished_project
+    end
+  end
+
   context "paperclip" do
     context "without cloudfront" do
       it { should have_attached_file(:icon) }

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -3,7 +3,10 @@ require "rails_helper"
 describe "Projects API" do
   context "GET /projects" do
     before do
-      @projects = create_list(:project, 10)
+      @projects = create_list(:project, 10, :with_categories)
+      # Publish them
+      @projects.each { |p| p.update(true) }
+      create_list(:project, 10)
     end
 
     context "when successful" do
@@ -15,7 +18,7 @@ describe "Projects API" do
         expect(last_response.status).to eq 200
       end
 
-      it "returns a list of projects, serialized with ProjectSerializer, with nothing included" do
+      it "returns a list of published projects, serialized, with nothing included" do
         expect(json).to serialize_collection(@projects).with(ProjectSerializer)
       end
     end
@@ -47,7 +50,10 @@ describe "Projects API" do
   context "GET /:slug/projects" do
     before do
       @slugged_route = create(:organization).slugged_route
-      @projects = create_list(:project, 3, organization: @slugged_route.owner)
+      @projects = create_list(:project, 3, :with_categories, organization: @slugged_route.owner)
+      # Publish them
+      @projects.each { |p| p.update(true) }
+      create_list(:project, 3, organization: @slugged_route.owner)
       create_list(:project, 2, organization: create(:organization))
     end
 


### PR DESCRIPTION
Closes #265.

First stab. Really kind of gross in a lot of places, especially the testing story.

I'm also really not happy about the fact that there's no good way to show projects to organization admins only in an organization's page without explicitly checking for their admin status there. This is not yet implemented but I realized it was an edge case at the last moment.
