### PR TITLE
Hide sensitive user data unless the user themselves is requesting it

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -71,7 +71,7 @@ class UsersController < ApplicationController
     user = User.find_by(email: forgot_password_params[:email])
 
     if user && user.forgot_password!
-      render json: user
+      render json: user, include_email: true
     else
       render_no_such_email_error
     end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -45,4 +45,26 @@ class UserSerializer < ActiveModel::Serializer
   def photo_large_url
     object.photo.url(:large)
   end
+
+  def email
+    serialize_if_current_user(object.email)
+  end
+
+  def facebook_id
+    serialize_if_current_user(object.facebook_id)
+  end
+
+  def facebook_access_token
+    serialize_if_current_user(object.facebook_access_token)
+  end
+
+  private
+
+    def serialize_if_current_user(attribute)
+      (current_user? || @instance_options[:include_email]) ? attribute : nil
+    end
+
+    def current_user?
+      object == scope
+    end
 end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -28,7 +28,7 @@ describe "Users API" do
 
       it "returns a proper response", aggregate_failures: true do
         expect(last_response.status).to eq 200
-        expect(json).to serialize_object(@user).with(UserSerializer)
+        expect(json).to serialize_object(@user).with(UserSerializer).with_scope(@user)
       end
     end
   end
@@ -206,7 +206,7 @@ describe "Users API" do
 
         user_attributes = json.data.attributes
 
-        expect(user_attributes.email).to eq "josh@example.com"
+        expect(user_attributes.email).to be_nil
         expect(user_attributes.username).to eq "joshsmith"
         expect(user_attributes.password).to be_nil
       end

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -85,11 +85,6 @@ describe UserSerializer, type: :serializer do
         expect(subject["created_at"]).to_not be_nil
       end
 
-      it "has an 'email'" do
-        expect(subject["email"]).to eq resource.email
-        expect(subject["email"]).to_not be_nil
-      end
-
       it "has a 'username'" do
         expect(subject["username"]).to eq resource.username
         expect(subject["username"]).to_not be_nil
@@ -115,16 +110,6 @@ describe UserSerializer, type: :serializer do
         expect(subject["biography"]).to_not be_nil
       end
 
-      it "has a 'facebook_id'" do
-        expect(subject["facebook_id"]).to eq resource.facebook_id
-        expect(subject["facebook_id"]).to_not be_nil
-      end
-
-      it "has a 'facebook_access_token'" do
-        expect(subject["facebook_access_token"]).to eq resource.facebook_access_token
-        expect(subject["facebook_access_token"]).to_not be_nil
-      end
-
       it "has a 'photo_thumb_url'" do
         expect(subject["photo_thumb_url"]).to eq resource.photo.url(:thumb)
         expect(subject["photo_thumb_url"]).to_not be_nil
@@ -138,6 +123,38 @@ describe UserSerializer, type: :serializer do
       it "has a 'state'" do
         expect(subject["state"]).to eq resource.state
         expect(subject["state"]).to_not be_nil
+      end
+
+      context "when not the current user" do
+        it "does not expose 'email'" do
+          expect(subject["email"]).to be_nil
+        end
+
+        it "does not expose 'facebook_id'" do
+          expect(subject["facebook_id"]).to be_nil
+        end
+
+        it "does not expose 'facebook_access_token'" do
+          expect(subject["facebook_access_token"]).to be_nil
+        end
+      end
+
+      context "when is the current user" do
+        before do
+          serializer.scope = resource
+        end
+
+        it "has an 'email'" do
+          expect(subject["email"]).to eq resource.email
+        end
+
+        it "has a 'facebook_id'" do
+          expect(subject["facebook_id"]).to eq resource.facebook_id
+        end
+
+        it "has a 'facebook_access_token'" do
+          expect(subject["facebook_access_token"]).to eq resource.facebook_access_token
+        end
       end
     end
 

--- a/spec/support/matchers/serializer_matchers.rb
+++ b/spec/support/matchers/serializer_matchers.rb
@@ -1,16 +1,19 @@
 RSpec::Matchers.define :serialize_object do |object|
   match do |json|
-    serializer =  @serializer_klass.new(object)
-    serialization = ActiveModel::Serializer::Adapter.create(serializer, include: includes)
+    serialization = ActiveModel::Serializer::Adapter.create(@serializer, include: includes)
     JSON.parse(serialization.to_json) == json
   end
 
   chain :with do |serializer_klass|
-    @serializer_klass = serializer_klass
+    @serializer = serializer_klass.new(object)
   end
 
   chain :with_includes do |includes|
     @includes = Array.wrap(includes)
+  end
+
+  chain :with_scope do |scope|
+    @serializer.scope = scope
   end
 
   def includes


### PR DESCRIPTION
Fixes #243.

This is failing because the email no longer returns on `forgot_password`. This is also true on `create`.

As per discussion below, we need to separate out the reset password actions and also the fix the `create` action. Need to pick a path.
