### PR TITLE
Allow post type to be edited

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -54,8 +54,7 @@ class PostsController < ApplicationController
 
     authorize post
 
-    post.assign_attributes(update_params_for_draft) if post.draft?
-    post.assign_attributes(update_params_for_published) unless post.draft?
+    post.assign_attributes(update_params)
 
     if post.update(publish?)
       GeneratePostUserNotificationsWorker.perform_async(post.id) if publish?
@@ -71,12 +70,9 @@ class PostsController < ApplicationController
       true unless parse_params(params).fetch(:preview, false)
     end
 
-    def update_params_for_published
-      parse_params(params, only: [:markdown_preview, :title])
-    end
-
-    def update_params_for_draft
-      parse_params(params, only: [:markdown_preview, :title, :post_type])
+    def update_params
+      return parse_params(params, only: [:markdown_preview, :title]) unless publish?
+      return parse_params(params, only: [:markdown_preview, :title, :post_type]) if publish?
     end
 
     def create_params

--- a/spec/requests/api/posts_spec.rb
+++ b/spec/requests/api/posts_spec.rb
@@ -373,16 +373,15 @@ describe "Posts API" do
 
             # attributes are properly set
             expect(post.title).to eq "Edited title"
-            # post_type parameter was accepted
-            expect(post.task?).to be true
+
+            # post_type parameter was ignored
+            expect(post.issue?).to be true
+
             expect(post.body).to be_nil
             expect(post.markdown).to be_nil
             expect(post.body_preview).
               to eq "<p>@#{mentioned_1.username} @#{mentioned_2.username}</p>"
             expect(post.markdown_preview).to eq "@#{mentioned_1.username} @#{mentioned_2.username}"
-
-            # post type was set
-            expect(post.post_type).to eq "task"
 
             # relationships are properly set
             expect(post.user_id).to eq user.id
@@ -412,8 +411,10 @@ describe "Posts API" do
 
             # attributes are properly set
             expect(post.title).to eq "Edited title"
+
             # post_type parameter was accepted
             expect(post.task?).to be true
+
             expect(post.body).to eq "<p>@#{mentioned_1.username} @#{mentioned_2.username}</p>"
             expect(post.markdown).to eq "@#{mentioned_1.username} @#{mentioned_2.username}"
             expect(post.body_preview).
@@ -461,11 +462,12 @@ describe "Posts API" do
 
         context "when requesting an actual save" do
           it "updates and post and sets it to edited state" do
-            params[:data][:attributes][:publish] = true
             make_request_with_sidekiq_inline params
 
-            # post_type parameter was ignored
-            expect(post.task?).to be false
+            post.reload
+
+            # post_type parameter was accepted
+            expect(post.task?).to be true
 
             # response is correct
             expect(last_response.status).to eq 200


### PR DESCRIPTION
Closes #312 

Requires client changes as well, but can be merged without it.
