### PR TITLE
Allow post filtering by status

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -83,6 +83,7 @@ class PostsController < ApplicationController
     def filter_params
       filter_params = {}
       filter_params[:post_type] = params[:post_type].split(",") if params[:post_type]
+      filter_params[:status] = params[:status] if params[:status]
       filter_params
     end
 


### PR DESCRIPTION
Closes #321 

I wrote it so the API doesn't make any assumptions about default status. Assuming an "open" status would make it impossible to fetch both closed and open posts.
