### PR TITLE
Simplify preview behavior

### DIFF
--- a/app/controllers/comment_user_mentions_controller.rb
+++ b/app/controllers/comment_user_mentions_controller.rb
@@ -11,7 +11,6 @@
 #  end_index   :integer          not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  status      :string           default("preview"), not null
 #
 
 class CommentUserMentionsController < ApplicationController
@@ -25,8 +24,7 @@ class CommentUserMentionsController < ApplicationController
 
     def filter_params
       {
-        comment_id: params[:comment_id],
-        status: params[:status]
+        comment_id: params[:comment_id]
       }
     end
 end

--- a/app/controllers/post_user_mentions_controller.rb
+++ b/app/controllers/post_user_mentions_controller.rb
@@ -10,7 +10,6 @@
 #  end_index   :integer          not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  status      :string           default("preview"), not null
 #
 
 class PostUserMentionsController < ApplicationController
@@ -24,8 +23,7 @@ class PostUserMentionsController < ApplicationController
 
     def filter_params
       {
-        post_id: params[:post_id],
-        status: params[:status]
+        post_id: params[:post_id]
       }
     end
 end

--- a/app/controllers/preview_user_mentions_controller.rb
+++ b/app/controllers/preview_user_mentions_controller.rb
@@ -1,10 +1,9 @@
 # == Schema Information
 #
-# Table name: comment_user_mentions
+# Table name: post_user_mentions
 #
 #  id          :integer          not null, primary key
 #  user_id     :integer          not null
-#  comment_id  :integer          not null
 #  post_id     :integer          not null
 #  username    :string           not null
 #  start_index :integer          not null
@@ -13,13 +12,16 @@
 #  updated_at  :datetime         not null
 #
 
-FactoryGirl.define do
-  factory :comment_user_mention do
-    association :user
-    association :comment
-    association :post
-
-    sequence(:start_index) { |n| n }
-    sequence(:end_index) { |n| n }
+class PreviewUserMentionsController < ApplicationController
+  def index
+    authorize PreviewUserMention
+    mentions = PreviewUserMention.includes(:user, :preview).where(filter_params)
+    render json: mentions
   end
+
+  private
+
+    def filter_params
+      { preview_id: params[:preview_id] }
+    end
 end

--- a/app/controllers/previews_controller.rb
+++ b/app/controllers/previews_controller.rb
@@ -1,0 +1,35 @@
+# == Schema Information
+#
+# Table name: previews
+#
+#  id         :integer          not null, primary key
+#  body       :text             not null
+#  markdown   :text             not null
+#  user_id    :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class PreviewsController < ApplicationController
+  before_action :doorkeeper_authorize!, only: [:create]
+
+  def create
+    preview = Preview.new(create_params)
+
+    if preview.save
+      render json: preview
+    else
+      render_validation_errors preview.errors
+    end
+  end
+
+  private
+
+    def create_params
+      params_for_user(permitted_params)
+    end
+
+    def permitted_params
+      parse_params(params, only: [:markdown])
+    end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,20 +2,18 @@
 #
 # Table name: comments
 #
-#  id               :integer          not null, primary key
-#  body             :text
-#  user_id          :integer          not null
-#  post_id          :integer          not null
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  markdown         :text
-#  aasm_state       :string
-#  body_preview     :text
-#  markdown_preview :text
+#  id         :integer          not null, primary key
+#  body       :text
+#  user_id    :integer          not null
+#  post_id    :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  markdown   :text
+#  aasm_state :string
 #
 
 require "html/pipeline"
-require 'html/pipeline/rouge_filter'
+require "html/pipeline/rouge_filter"
 require "code_corps/scenario/generate_user_mentions_for_comment"
 
 class Comment < ActiveRecord::Base
@@ -26,51 +24,35 @@ class Comment < ActiveRecord::Base
 
   has_many :comment_user_mentions
 
-  validates :body, presence: true, unless: :draft?
-  validates :markdown, presence: true, unless: :draft?
-
-  validates_presence_of :user
-  validates_presence_of :post
+  validates :body, presence: true
+  validates :markdown, presence: true
+  validates :post, presence: true
+  validates :user, presence: true
 
   before_validation :render_markdown_to_body
-  before_validation :publish_changes
 
   after_create :track_created
 
   after_save :generate_mentions
-
-  attr_accessor :publishing
-  alias_method :publishing?, :publishing
+  after_save :track_edited
 
   aasm do
-    state :draft, initial: true
-    state :published
+    state :published, initial: true
     state :edited
 
-    event :publish, after: :track_published do
-      transitions from: :draft, to: :published
-    end
-
-    event :edit, after: :track_edited do
+    event :edit do
       transitions from: :published, to: :edited
     end
   end
 
   default_scope { order(id: :asc) }
 
-  scope :active, -> { where("aasm_state=? OR aasm_state=?", "published", "edited") }
-
-  def update(publishing)
-    @publishing = publishing
-    save
-  end
-
   def state
     aasm_state
   end
 
   def state=(value)
-    publish if value == "published" && draft?
+    edit if value == "edited" && published?
   end
 
   def edited_at
@@ -83,21 +65,6 @@ class Comment < ActiveRecord::Base
       CodeCorps::Scenario::GenerateUserMentionsForComment.new(self).call
     end
 
-    def render_markdown_to_body
-      return unless markdown_preview_changed?
-      html = pipeline.call(markdown_preview)
-      self.body_preview = html[:output].to_s
-    end
-
-    def publish_changes
-      return unless publishing?
-
-      edit if published?
-      publish if draft?
-
-      assign_attributes markdown: markdown_preview, body: body_preview
-    end
-
     def pipeline
       @pipeline ||= HTML::Pipeline.new [
         HTML::Pipeline::MarkdownFilter,
@@ -105,16 +72,17 @@ class Comment < ActiveRecord::Base
       ], gfm: true # Github-flavored markdown
     end
 
+    def render_markdown_to_body
+      html = pipeline.call(markdown)
+      self.body = html[:output].to_s
+    end
+
     def track_created
       analytics.track_created_comment(self)
     end
 
     def track_edited
-      analytics.track_edited_comment(self)
-    end
-
-    def track_published
-      analytics.track_published_comment(self)
+      analytics.track_edited_comment(self) if edited?
     end
 
     def analytics

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -16,8 +16,6 @@
 #  number           :integer
 #  aasm_state       :string
 #  comments_count   :integer          default(0)
-#  body_preview     :text
-#  markdown_preview :text
 #
 
 require "html/pipeline"
@@ -35,28 +33,23 @@ class Post < ActiveRecord::Base
   has_many :post_user_mentions
   has_many :comment_user_mentions
 
-  acts_as_sequenced scope: :project_id, column: :number, skip: ->(r) { r.draft? }
+  acts_as_sequenced scope: :project_id, column: :number
 
-  validates_presence_of :project
-  validates_presence_of :user
-
-  validates :title, presence: true, unless: :draft?
-  validates :body, presence: true, unless: :draft?
-  validates :markdown, presence: true, unless: :draft?
-
-  validates_presence_of :post_type
+  validates :body, presence: true
+  validates :markdown, presence: true
+  validates :post_type, presence: true
+  validates :project, presence: true
+  validates :title, presence: true
+  validates :user, presence: true
 
   validates_uniqueness_of :number, scope: :project_id, allow_nil: true
 
   before_validation :render_markdown_to_body
-  before_validation :publish_changes
 
   after_create :track_created
 
   after_save :generate_mentions
-
-  attr_accessor :publishing
-  alias_method :publishing?, :publishing
+  after_save :track_edited
 
   enum status: {
     open: "open",
@@ -70,34 +63,22 @@ class Post < ActiveRecord::Base
   }
 
   aasm do
-    state :draft, initial: true
-    state :published
+    state :published, initial: true
     state :edited
 
-    event :publish, after: :track_published do
-      transitions from: :draft, to: :published
-    end
-
-    event :edit, after: :track_edited do
+    event :edit do
       transitions from: :published, to: :edited
     end
   end
 
-  default_scope  { order(number: :desc) }
-
-  scope :active, -> { where("aasm_state=? OR aasm_state=?", "published", "edited") }
-
-  def update(publishing)
-    @publishing = publishing
-    save
-  end
+  default_scope { order(number: :desc) }
 
   def state
     aasm_state
   end
 
   def state=(value)
-    publish if value == "published" && draft?
+    edit if value == "edited" && published?
   end
 
   def edited_at
@@ -117,19 +98,9 @@ class Post < ActiveRecord::Base
       ], gfm: true # Github-flavored markdown
     end
 
-    def publish_changes
-      return unless publishing?
-
-      edit if published?
-      publish if draft?
-
-      assign_attributes markdown: markdown_preview, body: body_preview
-    end
-
     def render_markdown_to_body
-      return unless markdown_preview_changed?
-      html = pipeline.call(markdown_preview)
-      self.body_preview = html[:output].to_s
+      html = pipeline.call(markdown)
+      self.body = html[:output].to_s
     end
 
     def track_created
@@ -137,11 +108,7 @@ class Post < ActiveRecord::Base
     end
 
     def track_edited
-      analytics.track_edited_post(self)
-    end
-
-    def track_published
-      analytics.track_published_post(self)
+      analytics.track_edited_post(self) if edited?
     end
 
     def analytics

--- a/app/models/post_user_mention.rb
+++ b/app/models/post_user_mention.rb
@@ -10,7 +10,6 @@
 #  end_index   :integer          not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  status      :string           default("preview"), not null
 #
 
 class PostUserMention < ActiveRecord::Base
@@ -24,8 +23,6 @@ class PostUserMention < ActiveRecord::Base
   validates_presence_of :end_index
 
   before_validation :add_username_from_user
-
-  enum status: { preview: "preview", published: "published" }
 
   def indices
     [start_index, end_index]

--- a/app/models/preview.rb
+++ b/app/models/preview.rb
@@ -1,0 +1,47 @@
+# == Schema Information
+#
+# Table name: previews
+#
+#  id         :integer          not null, primary key
+#  body       :text             not null
+#  markdown   :text             not null
+#  user_id    :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+require "html/pipeline"
+require "html/pipeline/rouge_filter"
+require "code_corps/scenario/generate_preview_mentions"
+
+class Preview < ActiveRecord::Base
+  belongs_to :user
+
+  has_many :preview_user_mentions
+
+  validates :body, presence: true
+  validates :markdown, presence: true
+  validates :user, presence: true
+
+  before_validation :render_markdown_to_body
+
+  after_save :generate_mentions
+
+  private
+
+    def generate_mentions
+      CodeCorps::Scenario::GeneratePreviewMentions.new(self).call
+    end
+
+    def pipeline
+      @pipeline ||= HTML::Pipeline.new [
+        HTML::Pipeline::MarkdownFilter,
+        HTML::Pipeline::RougeFilter
+      ], gfm: true # Github-flavored markdown
+    end
+
+    def render_markdown_to_body
+      html = pipeline.call(markdown)
+      self.body = html[:output].to_s
+    end
+end

--- a/app/models/preview_user_mention.rb
+++ b/app/models/preview_user_mention.rb
@@ -1,11 +1,10 @@
 # == Schema Information
 #
-# Table name: comment_user_mentions
+# Table name: preview_user_mentions
 #
 #  id          :integer          not null, primary key
 #  user_id     :integer          not null
-#  comment_id  :integer          not null
-#  post_id     :integer          not null
+#  preview_id  :integer          not null
 #  username    :string           not null
 #  start_index :integer          not null
 #  end_index   :integer          not null
@@ -13,19 +12,17 @@
 #  updated_at  :datetime         not null
 #
 
-class CommentUserMention < ActiveRecord::Base
+class PreviewUserMention < ActiveRecord::Base
+  belongs_to :preview
   belongs_to :user
-  belongs_to :comment
-  belongs_to :post
-
-  validates_presence_of :user
-  validates_presence_of :comment
-  validates_presence_of :post
-  validates_presence_of :username
-  validates_presence_of :start_index
-  validates_presence_of :end_index
 
   before_validation :add_username_from_user
+
+  validates :end_index, presence: true
+  validates :preview, presence: true
+  validates :start_index, presence: true
+  validates :user, presence: true
+  validates :username, presence: true
 
   def indices
     [start_index, end_index]

--- a/app/policies/preview_user_mention_policy.rb
+++ b/app/policies/preview_user_mention_policy.rb
@@ -1,0 +1,12 @@
+class PreviewUserMentionPolicy
+  attr_reader :user, :preview_user_mention
+
+  def initialize(user, preview_user_mention)
+    @user = user
+    @preview_user_mention = preview_user_mention
+  end
+
+  def index?
+    true
+  end
+end

--- a/app/serializers/comment_serializer.rb
+++ b/app/serializers/comment_serializer.rb
@@ -2,21 +2,18 @@
 #
 # Table name: comments
 #
-#  id               :integer          not null, primary key
-#  body             :text
-#  user_id          :integer          not null
-#  post_id          :integer          not null
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  markdown         :text
-#  aasm_state       :string
-#  body_preview     :text
-#  markdown_preview :text
+#  id         :integer          not null, primary key
+#  body       :text
+#  user_id    :integer          not null
+#  post_id    :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  markdown   :text
+#  aasm_state :string
 #
 
 class CommentSerializer < ActiveModel::Serializer
-  attributes :id, :state, :body, :body_preview, :markdown, :markdown_preview,
-             :edited_at, :created_at
+  attributes :id, :state, :body, :markdown, :edited_at, :created_at
 
   belongs_to :post
   belongs_to :user

--- a/app/serializers/comment_user_mention_serializer.rb
+++ b/app/serializers/comment_user_mention_serializer.rb
@@ -11,11 +11,10 @@
 #  end_index   :integer          not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  status      :string           default("preview"), not null
 #
 
 class CommentUserMentionSerializer < ActiveModel::Serializer
-  attributes :id, :indices, :username, :status
+  attributes :id, :indices, :username
 
   belongs_to :user
   belongs_to :comment, serializer: CommentSerializer

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -16,14 +16,12 @@
 #  number           :integer
 #  aasm_state       :string
 #  comments_count   :integer          default(0)
-#  body_preview     :text
-#  markdown_preview :text
 #
 
 class PostSerializer < ActiveModel::Serializer
   attributes :id, :number, :post_type, :state, :status,
-             :title, :body, :body_preview, :markdown, :markdown_preview,
-             :likes_count, :comments_count, :created_at, :edited_at
+             :title, :body, :markdown, :likes_count, :comments_count,
+             :created_at, :edited_at
 
   has_many :comments
   has_many :post_user_mentions

--- a/app/serializers/post_serializer_without_includes.rb
+++ b/app/serializers/post_serializer_without_includes.rb
@@ -1,7 +1,6 @@
 class PostSerializerWithoutIncludes < ActiveModel::Serializer
   attributes :id, :number, :post_type, :state, :status,
-             :title, :body, :body_preview, :markdown, :markdown_preview,
-             :likes_count, :comments_count,
+             :title, :body, :markdown, :likes_count, :comments_count,
              :edited_at
 
   def likes_count

--- a/app/serializers/post_user_mention_serializer.rb
+++ b/app/serializers/post_user_mention_serializer.rb
@@ -10,11 +10,10 @@
 #  end_index   :integer          not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  status      :string           default("preview"), not null
 #
 
 class PostUserMentionSerializer < ActiveModel::Serializer
-  attributes :id, :indices, :username, :status
+  attributes :id, :indices, :username
 
   belongs_to :user
   belongs_to :post, serializer: PostSerializerWithoutIncludes

--- a/app/serializers/preview_serializer.rb
+++ b/app/serializers/preview_serializer.rb
@@ -1,0 +1,17 @@
+# == Schema Information
+#
+# Table name: previews
+#
+#  id         :integer          not null, primary key
+#  body       :text             not null
+#  markdown   :text             not null
+#  user_id    :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class PreviewSerializer < ActiveModel::Serializer
+  attributes :id, :body, :markdown
+
+  has_many :preview_user_mentions
+end

--- a/app/serializers/preview_user_mention_serializer.rb
+++ b/app/serializers/preview_user_mention_serializer.rb
@@ -1,11 +1,10 @@
 # == Schema Information
 #
-# Table name: comment_user_mentions
+# Table name: preview_user_mentions
 #
 #  id          :integer          not null, primary key
 #  user_id     :integer          not null
-#  comment_id  :integer          not null
-#  post_id     :integer          not null
+#  preview_id  :integer          not null
 #  username    :string           not null
 #  start_index :integer          not null
 #  end_index   :integer          not null
@@ -13,13 +12,9 @@
 #  updated_at  :datetime         not null
 #
 
-FactoryGirl.define do
-  factory :comment_user_mention do
-    association :user
-    association :comment
-    association :post
+class PreviewUserMentionSerializer < ActiveModel::Serializer
+  attributes :id, :indices, :username
 
-    sequence(:start_index) { |n| n }
-    sequence(:end_index) { |n| n }
-  end
+  belongs_to :preview
+  belongs_to :user
 end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -92,28 +92,6 @@ class Analytics
     track(event: "Edited Profile in Onboarding")
   end
 
-  def track_previewed_existing_comment
-    track(event: "Previewed Existing Comment")
-  end
-
-  def track_previewed_new_comment
-    track(event: "Previewed New Comment")
-  end
-
-  def track_published_comment(comment)
-    track(
-      event: "Published Comment",
-      properties: properties_for_comment(comment)
-    )
-  end
-
-  def track_published_post(post)
-    track(
-      event: "Published Post",
-      properties: properties_for_post(post)
-    )
-  end
-
   def track_rejected_organization_membership(organization_membership)
     track(
       event: "Rejected Organization Membership",

--- a/app/workers/generate_comment_user_notifications_worker.rb
+++ b/app/workers/generate_comment_user_notifications_worker.rb
@@ -6,7 +6,6 @@ class GenerateCommentUserNotificationsWorker
 
   def perform(comment_id)
     comment = Comment.find(comment_id)
-    return if comment.draft?
     CodeCorps::Scenario::GenerateNotificationsForCommentUserMentions.new(comment).call
     CodeCorps::Scenario::SendNotificationEmails.new(comment).call
   end

--- a/app/workers/generate_post_user_notifications_worker.rb
+++ b/app/workers/generate_post_user_notifications_worker.rb
@@ -6,9 +6,7 @@ class GeneratePostUserNotificationsWorker
 
   def perform(post_id)
     post = Post.find(post_id)
-    return if post.draft?
     CodeCorps::Scenario::GenerateNotificationsForPostUserMentions.new(post).call
     CodeCorps::Scenario::SendNotificationEmails.new(post).call
   end
-
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,9 @@ Rails.application.routes.draw do
     resources :post_likes, only: [:create, :destroy]
     resources :post_user_mentions, only: [:index]
 
+    resources :previews, only: [:create]
+    resources :preview_user_mentions, only: [:index]
+
     resources :projects, only: [:index, :create, :update] do
       resources :posts, only: [:index, :show]
     end

--- a/db/migrate/20160621003651_create_previews.rb
+++ b/db/migrate/20160621003651_create_previews.rb
@@ -1,0 +1,12 @@
+class CreatePreviews < ActiveRecord::Migration
+  def change
+    create_table :previews do |t|
+      t.text :body, null: false
+      t.text :markdown, null: false
+
+      t.belongs_to :user, index: true, foreign_key: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160621003916_create_preview_user_mentions.rb
+++ b/db/migrate/20160621003916_create_preview_user_mentions.rb
@@ -1,0 +1,14 @@
+class CreatePreviewUserMentions < ActiveRecord::Migration
+  def change
+    create_table :preview_user_mentions do |t|
+      t.belongs_to :user, index: true, foreign_key: true, null: false
+      t.belongs_to :preview, index: true, foreign_key: true, null: false
+
+      t.string :username, null: false
+      t.integer :start_index, null: false
+      t.integer :end_index, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160621024455_remove_preview_fields_from_posts.rb
+++ b/db/migrate/20160621024455_remove_preview_fields_from_posts.rb
@@ -1,0 +1,6 @@
+class RemovePreviewFieldsFromPosts < ActiveRecord::Migration
+  def change
+    remove_column :posts, :body_preview, :string
+    remove_column :posts, :markdown_preview, :string
+  end
+end

--- a/db/migrate/20160621024928_remove_preview_fields_from_comments.rb
+++ b/db/migrate/20160621024928_remove_preview_fields_from_comments.rb
@@ -1,0 +1,6 @@
+class RemovePreviewFieldsFromComments < ActiveRecord::Migration
+  def change
+    remove_column :comments, :body_preview, :string
+    remove_column :comments, :markdown_preview, :string
+  end
+end

--- a/db/migrate/20160621031228_remove_status_from_user_mentions.rb
+++ b/db/migrate/20160621031228_remove_status_from_user_mentions.rb
@@ -1,0 +1,6 @@
+class RemoveStatusFromUserMentions < ActiveRecord::Migration
+  def change
+    remove_column :comment_user_mentions, :status, :string, null: false, default: "preview"
+    remove_column :post_user_mentions, :status, :string, null: false, default: "preview"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160609202045) do
+ActiveRecord::Schema.define(version: 20160621031228) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,27 +40,24 @@ ActiveRecord::Schema.define(version: 20160609202045) do
   end
 
   create_table "comment_user_mentions", force: :cascade do |t|
-    t.integer  "user_id",                         null: false
-    t.integer  "comment_id",                      null: false
-    t.integer  "post_id",                         null: false
-    t.string   "username",                        null: false
-    t.integer  "start_index",                     null: false
-    t.integer  "end_index",                       null: false
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
-    t.string   "status",      default: "preview", null: false
+    t.integer  "user_id",     null: false
+    t.integer  "comment_id",  null: false
+    t.integer  "post_id",     null: false
+    t.string   "username",    null: false
+    t.integer  "start_index", null: false
+    t.integer  "end_index",   null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
   end
 
   create_table "comments", force: :cascade do |t|
     t.text     "body"
-    t.integer  "user_id",          null: false
-    t.integer  "post_id",          null: false
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
+    t.integer  "user_id",    null: false
+    t.integer  "post_id",    null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.text     "markdown"
     t.string   "aasm_state"
-    t.text     "body_preview"
-    t.text     "markdown_preview"
   end
 
   create_table "github_repositories", force: :cascade do |t|
@@ -169,14 +166,13 @@ ActiveRecord::Schema.define(version: 20160609202045) do
   end
 
   create_table "post_user_mentions", force: :cascade do |t|
-    t.integer  "user_id",                         null: false
-    t.integer  "post_id",                         null: false
-    t.string   "username",                        null: false
-    t.integer  "start_index",                     null: false
-    t.integer  "end_index",                       null: false
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
-    t.string   "status",      default: "preview", null: false
+    t.integer  "user_id",     null: false
+    t.integer  "post_id",     null: false
+    t.string   "username",    null: false
+    t.integer  "start_index", null: false
+    t.integer  "end_index",   null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
   end
 
   create_table "posts", force: :cascade do |t|
@@ -193,9 +189,30 @@ ActiveRecord::Schema.define(version: 20160609202045) do
     t.integer  "number"
     t.string   "aasm_state"
     t.integer  "comments_count",   default: 0
-    t.text     "body_preview"
-    t.text     "markdown_preview"
   end
+
+  create_table "preview_user_mentions", force: :cascade do |t|
+    t.integer  "user_id",     null: false
+    t.integer  "preview_id",  null: false
+    t.string   "username",    null: false
+    t.integer  "start_index", null: false
+    t.integer  "end_index",   null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
+
+  add_index "preview_user_mentions", ["preview_id"], name: "index_preview_user_mentions_on_preview_id", using: :btree
+  add_index "preview_user_mentions", ["user_id"], name: "index_preview_user_mentions_on_user_id", using: :btree
+
+  create_table "previews", force: :cascade do |t|
+    t.text     "body",       null: false
+    t.text     "markdown",   null: false
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "previews", ["user_id"], name: "index_previews_on_user_id", using: :btree
 
   create_table "project_categories", force: :cascade do |t|
     t.integer  "project_id"
@@ -236,6 +253,7 @@ ActiveRecord::Schema.define(version: 20160609202045) do
     t.text     "base64_icon_data"
     t.string   "slug",              null: false
     t.integer  "organization_id",   null: false
+    t.string   "aasm_state"
   end
 
   add_index "projects", ["organization_id"], name: "index_projects_on_organization_id", using: :btree
@@ -336,6 +354,9 @@ ActiveRecord::Schema.define(version: 20160609202045) do
   add_foreign_key "comments", "users"
   add_foreign_key "posts", "projects"
   add_foreign_key "posts", "users"
+  add_foreign_key "preview_user_mentions", "previews"
+  add_foreign_key "preview_user_mentions", "users"
+  add_foreign_key "previews", "users"
   add_foreign_key "project_categories", "categories", on_delete: :cascade
   add_foreign_key "project_categories", "projects", on_delete: :cascade
   add_foreign_key "project_roles", "projects", on_delete: :cascade

--- a/lib/code_corps/scenario/generate_preview_mentions.rb
+++ b/lib/code_corps/scenario/generate_preview_mentions.rb
@@ -1,20 +1,21 @@
 module CodeCorps
   module Scenario
-    class GenerateUserMentionsForPost
-      def initialize(post)
-        @post = post
+    class GeneratePreviewMentions
+      def initialize(preview)
+        @preview = preview
       end
 
-      attr_reader :post
+      attr_reader :preview
 
       def call
         ActiveRecord::Base.transaction do
-          destroy_existing_mentions
           mentions.each do |m|
-            PostUserMention.create!(
-              post: @post, user: m[0],
-              start_index: m[1], end_index: m[2],
-              username: m[0].username
+            PreviewUserMention.create!(
+              preview: @preview,
+              user: m[0],
+              username: m[0].username,
+              start_index: m[1],
+              end_index: m[2],
             )
           end
         end
@@ -22,17 +23,12 @@ module CodeCorps
 
       private
 
-        def destroy_existing_mentions
-          existing_mentions = post.post_user_mentions
-          existing_mentions.destroy_all if existing_mentions.present?
-        end
-
         def regex_matches
           regex = %r{\B@((?:(?:(?:[^-\W]-?))*)(?:[^\/\W]\/?)?(?:(?:(?:[^-\W]-?))*)\w+)}
 
           result = []
 
-          content = post.body
+          content = preview.body
 
           return if content.nil?
 

--- a/spec/factories/comment_factory.rb
+++ b/spec/factories/comment_factory.rb
@@ -2,49 +2,33 @@
 #
 # Table name: comments
 #
-#  id               :integer          not null, primary key
-#  body             :text
-#  user_id          :integer          not null
-#  post_id          :integer          not null
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  markdown         :text
-#  aasm_state       :string
-#  body_preview     :text
-#  markdown_preview :text
+#  id         :integer          not null, primary key
+#  body       :text
+#  user_id    :integer          not null
+#  post_id    :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  markdown   :text
+#  aasm_state :string
 #
 
 FactoryGirl.define do
-
   factory :comment do
     sequence(:markdown) { |n| "Comment #{n}" }
-    sequence(:markdown_preview) { |n| "Comment #{n}" }
 
     association :post
     association :user
-
-    trait :draft do
-      aasm_state :draft
-      markdown nil
-      body nil
-      markdown_preview "Comment content"
-      body_preview "Comment content"
-    end
 
     trait :published do
       aasm_state :published
       markdown "Comment content"
       body "Comment content"
-      markdown_preview "Comment content"
-      body_preview "Comment content"
     end
 
     trait :edited do
       aasm_state :edited
       markdown "Comment content"
       body "Comment content"
-      markdown_preview "Comment content"
-      body_preview "Comment content"
     end
 
     trait :with_user_mentions do
@@ -57,5 +41,4 @@ FactoryGirl.define do
       end
     end
   end
-
 end

--- a/spec/factories/post_factory.rb
+++ b/spec/factories/post_factory.rb
@@ -16,42 +16,26 @@
 #  number           :integer
 #  aasm_state       :string
 #  comments_count   :integer          default(0)
-#  body_preview     :text
-#  markdown_preview :text
 #
 
 FactoryGirl.define do
-
   factory :post do
     sequence(:title) { |n| "Post #{n}" }
     sequence(:markdown) { |n| "Post content #{n}" }
-    sequence(:markdown_preview) { |n| "Post content #{n}" }
 
     association :user
     association :project
-
-    trait :draft do
-      aasm_state :draft
-      markdown nil
-      body nil
-      markdown_preview "Post content"
-      body_preview "Post content"
-    end
 
     trait :published do
       aasm_state :published
       markdown "Post content"
       body "Post content"
-      markdown_preview "Post content"
-      body_preview "Post content"
     end
 
     trait :edited do
       aasm_state :edited
       markdown "Post content"
       body "Post content"
-      markdown_preview "Post content"
-      body_preview "Post content"
     end
 
     trait :with_user_mentions do
@@ -68,5 +52,4 @@ FactoryGirl.define do
       sequence(:number) { |n| n }
     end
   end
-
 end

--- a/spec/factories/post_user_mention_factory.rb
+++ b/spec/factories/post_user_mention_factory.rb
@@ -10,11 +10,9 @@
 #  end_index   :integer          not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  status      :string           default("preview"), not null
 #
 
 FactoryGirl.define do
-
   factory :post_user_mention do
     association :user
     association :post
@@ -22,5 +20,4 @@ FactoryGirl.define do
     sequence(:start_index) { |n| n }
     sequence(:end_index) { |n| n }
   end
-
 end

--- a/spec/factories/preview_factory.rb
+++ b/spec/factories/preview_factory.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: previews
+#
+#  id         :integer          not null, primary key
+#  body       :text             not null
+#  markdown   :text             not null
+#  user_id    :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+FactoryGirl.define do
+  factory :preview do
+    sequence(:markdown) { |n| "Post content #{n}" }
+
+    association :user
+  end
+end

--- a/spec/factories/preview_user_mention.rb
+++ b/spec/factories/preview_user_mention.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :preview_user_mention do
+    association :user
+    association :preview
+
+    sequence(:start_index) { |n| n }
+    sequence(:end_index) { |n| n }
+  end
+end

--- a/spec/lib/code_corps/scenario/generate_preview_mentions_spec.rb
+++ b/spec/lib/code_corps/scenario/generate_preview_mentions_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+require "code_corps/scenario/generate_preview_mentions"
+
+module CodeCorps
+  module Scenario
+    describe GeneratePreviewMentions do
+      describe "#call" do
+        let(:user) { create(:user, username: "joshsmith") }
+        let(:preview) { create(:preview) }
+
+        before do
+          # need to disable the default after save hook which generates mentions
+          allow_any_instance_of(Preview).to receive(:generate_mentions)
+        end
+
+        it "creates user mentions from body when publishing" do
+          preview.markdown = "Mentioning @#{user.username}"
+          preview.save
+
+          GeneratePreviewMentions.new(preview).call
+
+          mention = PreviewUserMention.last
+          expect(mention.preview).to eq preview
+          expect(mention.user).to eq user
+          expect(mention.username).to eq user.username
+        end
+
+        it "does not fail when content is nil" do
+          preview.markdown = nil
+          preview.save
+          expect { GeneratePreviewMentions.new(preview).call }.not_to raise_error
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/code_corps/scenario/generate_user_mentions_for_comment_spec.rb
+++ b/spec/lib/code_corps/scenario/generate_user_mentions_for_comment_spec.rb
@@ -13,24 +13,9 @@ module CodeCorps
           allow_any_instance_of(Comment).to receive(:generate_mentions)
         end
 
-        it "creates user mentions for body_preview when previewing" do
-          comment.markdown_preview = "Mentioning @#{user.username}"
-          comment.update(false)
-
-          GenerateUserMentionsForComment.new(comment).call
-
-          mention = CommentUserMention.last
-          expect(mention.comment).to eq comment
-          expect(mention.user).to eq user
-          expect(mention.username).to eq user.username
-
-          post = comment.post
-          expect(post.comment_user_mentions).to include mention
-        end
-
-        it "creates user mentions from body when publishing" do
-          comment.markdown_preview = "Mentioning @#{user.username}"
-          comment.update(true)
+        it "creates user mentions for body" do
+          comment.markdown = "Mentioning @#{user.username}"
+          comment.save
 
           GenerateUserMentionsForComment.new(comment).call
 
@@ -44,31 +29,20 @@ module CodeCorps
         end
 
         it "does not fail when content is nil" do
-          comment.markdown_preview = nil
-          comment.update(false)
+          comment.markdown = nil
+          comment.save
           expect { GenerateUserMentionsForComment.new(comment).call }.not_to raise_error
         end
 
         context "when mentions already exist" do
           before do
-            create_list(:comment_user_mention, 2, comment: comment, status: :published)
-            create_list(:comment_user_mention, 3, comment: comment, status: :preview)
+            create_list(:comment_user_mention, 2, comment: comment)
           end
 
-          it "destroys preview mentions if preview was requested, leaves published mentions" do
-            comment.publishing = false
-            comment.body_preview = "@#{user.username}"
-            GenerateUserMentionsForComment.new(comment).call
-            expect(comment.comment_user_mentions.published.count).to eq 2
-            expect(comment.comment_user_mentions.preview.count).to eq 1
-          end
-
-          it "destroys published mentions if publish was requested, leaves preview mentions" do
-            comment.publishing = true
+          it "destroys previous mentions" do
             comment.body = "@#{user.username}"
             GenerateUserMentionsForComment.new(comment).call
-            expect(comment.comment_user_mentions.published.count).to eq 1
-            expect(comment.comment_user_mentions.preview.count).to eq 3
+            expect(comment.comment_user_mentions.count).to eq 1
           end
         end
       end

--- a/spec/models/comment_user_mention_spec.rb
+++ b/spec/models/comment_user_mention_spec.rb
@@ -11,8 +11,9 @@
 #  end_index   :integer          not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  status      :string           default("preview"), not null
 #
+
+require "rails_helper"
 
 RSpec.describe CommentUserMention, type: :model do
   describe "schema" do
@@ -22,9 +23,6 @@ RSpec.describe CommentUserMention, type: :model do
     it { should have_db_column(:username).of_type(:string).with_options(null: false) }
     it { should have_db_column(:start_index).of_type(:integer).with_options(null: false) }
     it { should have_db_column(:end_index).of_type(:integer).with_options(null: false) }
-    it do
-      should have_db_column(:status).of_type(:string).with_options(null: false, default: "preview")
-    end
     it { should have_db_column(:updated_at) }
     it { should have_db_column(:created_at) }
   end
@@ -42,10 +40,6 @@ RSpec.describe CommentUserMention, type: :model do
     it { should validate_presence_of(:username) }
     it { should validate_presence_of(:start_index) }
     it { should validate_presence_of(:end_index) }
-  end
-
-  describe "behavior" do
-    it { should define_enum_for(:status).with(preview: "preview", published: "published") }
   end
 
   describe "before_validation" do

--- a/spec/models/preview_spec.rb
+++ b/spec/models/preview_spec.rb
@@ -1,0 +1,60 @@
+# == Schema Information
+#
+# Table name: previews
+#
+#  id         :integer          not null, primary key
+#  body       :text             not null
+#  markdown   :text             not null
+#  user_id    :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+require "rails_helper"
+
+describe Preview, type: :model do
+  describe "schema" do
+    it { should have_db_column(:body).of_type(:text).with_options(null: false) }
+    it { should have_db_column(:markdown).of_type(:text).with_options(null: false) }
+    it { should have_db_column(:user_id).of_type(:integer) }
+  end
+
+  describe "relationships" do
+    it { should have_many(:preview_user_mentions) }
+  end
+
+  describe "validations" do
+    it { should validate_presence_of :body }
+    it { should validate_presence_of :markdown }
+    it { should validate_presence_of :user }
+  end
+
+  describe "preview user mentions" do
+    context "when updating a preview" do
+      it "creates mentions only for existing users" do
+        real_user = create(:user, username: "joshsmith")
+
+        preview = build(:preview, markdown: "Hello @joshsmith and @someone_who_doesnt_exist")
+
+        preview.save
+        mentions = preview.preview_user_mentions
+
+        expect(mentions.count).to eq 1
+        expect(mentions.first.user).to eq real_user
+      end
+
+      context "when usernames contain underscores" do
+        it "creates mentions and not <em> tags" do
+          underscored_user = create(:user, username: "a_real_username")
+
+          preview = build(:preview, markdown: "Hello @a_real_username and @not_a_real_username")
+          preview.save
+          mentions = preview.preview_user_mentions
+
+          expect(mentions.count).to eq 1
+          expect(mentions.first.user).to eq underscored_user
+        end
+      end
+    end
+  end
+end

--- a/spec/models/preview_user_mention_spec.rb
+++ b/spec/models/preview_user_mention_spec.rb
@@ -1,10 +1,10 @@
 # == Schema Information
 #
-# Table name: post_user_mentions
+# Table name: preview_user_mentions
 #
 #  id          :integer          not null, primary key
 #  user_id     :integer          not null
-#  post_id     :integer          not null
+#  preview_id  :integer          not null
 #  username    :string           not null
 #  start_index :integer          not null
 #  end_index   :integer          not null
@@ -14,9 +14,9 @@
 
 require "rails_helper"
 
-RSpec.describe PostUserMention, type: :model do
+RSpec.describe PreviewUserMention, type: :model do
   describe "schema" do
-    it { should have_db_column(:post_id).of_type(:integer).with_options(null: false) }
+    it { should have_db_column(:preview_id).of_type(:integer).with_options(null: false) }
     it { should have_db_column(:user_id).of_type(:integer).with_options(null: false) }
     it { should have_db_column(:username).of_type(:string).with_options(null: false) }
     it { should have_db_column(:start_index).of_type(:integer).with_options(null: false) }
@@ -27,12 +27,12 @@ RSpec.describe PostUserMention, type: :model do
 
   describe "relationships" do
     it { should belong_to(:user) }
-    it { should belong_to(:post) }
+    it { should belong_to(:preview) }
   end
 
   describe "validations" do
     it { should validate_presence_of(:user) }
-    it { should validate_presence_of(:post) }
+    it { should validate_presence_of(:preview) }
     it { should validate_presence_of(:username) }
     it { should validate_presence_of(:start_index) }
     it { should validate_presence_of(:end_index) }
@@ -41,14 +41,14 @@ RSpec.describe PostUserMention, type: :model do
   describe "before_validation" do
     it "automatically adds the user's username" do
       user = create(:user, username: "joshsmith")
-      mention = create(:post_user_mention, user: user)
+      mention = create(:preview_user_mention, user: user)
       expect(mention.username).to eq "joshsmith"
     end
   end
 
   describe "indices" do
     it "wraps the indices inside of an array" do
-      mention = create(:post_user_mention, start_index: 0, end_index: 140)
+      mention = create(:preview_user_mention, start_index: 0, end_index: 140)
       expect(mention.indices).to eq [0, 140]
     end
   end

--- a/spec/policies/preview_user_mention_policy_spec.rb
+++ b/spec/policies/preview_user_mention_policy_spec.rb
@@ -1,0 +1,9 @@
+describe PreviewUserMentionPolicy do
+  subject { described_class }
+
+  permissions :index? do
+    it "is permited for anyone" do
+      expect(subject).to permit(nil, nil)
+    end
+  end
+end

--- a/spec/requests/api/comment_user_mentions_spec.rb
+++ b/spec/requests/api/comment_user_mentions_spec.rb
@@ -4,48 +4,31 @@ describe "CommentUserMentions API" do
   context "GET /comment_user_mentions/" do
     let(:comment_a) do
       comment = create(:comment)
-      create_list(:comment_user_mention, 4, comment: comment, status: :preview)
-      create_list(:comment_user_mention, 3, comment: comment, status: :published)
+      create_list(:comment_user_mention, 4, comment: comment)
       comment
     end
 
     let(:comment_b) do
       comment = create(:comment)
-      create_list(:comment_user_mention, 1, comment: comment, status: :preview)
-      create_list(:comment_user_mention, 2, comment: comment, status: :published)
+      create_list(:comment_user_mention, 1, comment: comment)
       comment
     end
 
-    def make_request_for_comment(comment, status)
-      get "#{host}/comment_user_mentions/", status: status, comment_id: comment.id
+    def make_request_for_comment(comment)
+      get "#{host}/comment_user_mentions/", comment_id: comment.id
     end
 
     it "fetches mentions of specified status for specified comment" do
-      make_request_for_comment(comment_a, :preview)
+      make_request_for_comment(comment_a)
       expect(last_response.status).to eq 200
       expect(json).to(
-        serialize_collection(comment_a.comment_user_mentions.preview).
+        serialize_collection(comment_a.comment_user_mentions.all).
           with(CommentUserMentionSerializer)
       )
-
-      make_request_for_comment(comment_a, :published)
+      make_request_for_comment(comment_b)
       expect(last_response.status).to eq 200
       expect(json).to(
-        serialize_collection(comment_a.comment_user_mentions.published).
-          with(CommentUserMentionSerializer)
-      )
-
-      make_request_for_comment(comment_b, :preview)
-      expect(last_response.status).to eq 200
-      expect(json).to(
-        serialize_collection(comment_b.comment_user_mentions.preview).
-          with(CommentUserMentionSerializer)
-      )
-
-      make_request_for_comment(comment_b, :published)
-      expect(last_response.status).to eq 200
-      expect(json).to(
-        serialize_collection(comment_b.comment_user_mentions.published).
+        serialize_collection(comment_b.comment_user_mentions.all).
           with(CommentUserMentionSerializer)
       )
     end

--- a/spec/requests/api/post_user_mentions_spec.rb
+++ b/spec/requests/api/post_user_mentions_spec.rb
@@ -4,48 +4,32 @@ describe "PostUserMentions API" do
   context "GET /post_user_mentions/" do
     let(:post_a) do
       post = create(:post)
-      create_list(:post_user_mention, 4, post: post, status: :preview)
-      create_list(:post_user_mention, 3, post: post, status: :published)
+      create_list(:post_user_mention, 4, post: post)
       post
     end
 
     let(:post_b) do
       post = create(:post)
-      create_list(:post_user_mention, 1, post: post, status: :preview)
-      create_list(:post_user_mention, 2, post: post, status: :published)
+      create_list(:post_user_mention, 1, post: post)
       post
     end
 
-    def make_request_for_post(post, status)
-      get "#{host}/post_user_mentions/", status: status, post_id: post.id
+    def make_request_for_post(post)
+      get "#{host}/post_user_mentions/", post_id: post.id
     end
 
     it "fetches mentions of specified status for specified post" do
-      make_request_for_post(post_a, :preview)
+      make_request_for_post(post_a)
       expect(last_response.status).to eq 200
       expect(json).to(
-        serialize_collection(post_a.post_user_mentions.preview).
+        serialize_collection(post_a.post_user_mentions.all).
           with(PostUserMentionSerializer)
       )
 
-      make_request_for_post(post_a, :published)
+      make_request_for_post(post_b)
       expect(last_response.status).to eq 200
       expect(json).to(
-        serialize_collection(post_a.post_user_mentions.published).
-          with(PostUserMentionSerializer)
-      )
-
-      make_request_for_post(post_b, :preview)
-      expect(last_response.status).to eq 200
-      expect(json).to(
-        serialize_collection(post_b.post_user_mentions.preview).
-          with(PostUserMentionSerializer)
-      )
-
-      make_request_for_post(post_b, :published)
-      expect(last_response.status).to eq 200
-      expect(json).to(
-        serialize_collection(post_b.post_user_mentions.published).
+        serialize_collection(post_b.post_user_mentions.all).
           with(PostUserMentionSerializer)
       )
     end

--- a/spec/requests/api/posts_spec.rb
+++ b/spec/requests/api/posts_spec.rb
@@ -18,10 +18,9 @@ describe "Posts API" do
         create_list(:post, 3, :edited, project: @project, post_type: "idea")
       end
 
-      it "returns active posts (published and edited)" do
-        create_list(:post, 5, :draft, project: @project)
+      it "returns posts" do
         get "#{host}/projects/#{@project.id}/posts"
-        collection = Post.active.page(1).per(10)
+        collection = Post.page(1).per(10)
         expect(json).to(
           serialize_collection(collection).
             with(PostSerializer).
@@ -139,10 +138,9 @@ describe "Posts API" do
       end
 
       it "returns the post, serialized with PostSerializer, with users, comments and mentions included" do
-        expect(json).to serialize_object(Post.last)
-          .with(PostSerializer)
-          .with_includes(["users", "comments", "post_user_mentions", "comment_user_mentions",
-                          "comments_count"])
+        expect(json).to serialize_object(Post.last).
+          with(PostSerializer).
+          with_includes(%w(users comments post_user_mentions comment_user_mentions comments_count"))
       end
     end
   end
@@ -171,7 +169,7 @@ describe "Posts API" do
             type: "posts",
             attributes: {
               title: "Post title",
-              markdown_preview: "@#{mentioned_1.username} @#{mentioned_2.username}",
+              markdown: "@#{mentioned_1.username} @#{mentioned_2.username}",
               post_type: "issue"
             },
             relationships: {
@@ -197,44 +195,7 @@ describe "Posts API" do
         Sidekiq::Testing.inline! { make_request params }
       end
 
-      context "when requesting a preview" do
-        it "creates a draft" do
-          params[:data][:attributes][:preview] = true
-          make_request_with_sidekiq_inline params
-
-          post = Post.last
-
-          # response is correct
-          expect(last_response.status).to eq 200
-          expect(json).to serialize_object(post).with(PostSerializer)
-
-          # state is proper
-          expect(post.draft?).to be true
-
-          # attributes are properly set
-          expect(post.title).to eq "Post title"
-          expect(post.issue?).to be true
-          expect(post.body).to be_nil
-          expect(post.markdown).to be_nil
-          expect(post.body_preview).to eq "<p>@#{mentioned_1.username} @#{mentioned_2.username}</p>"
-          expect(post.markdown_preview).to eq "@#{mentioned_1.username} @#{mentioned_2.username}"
-
-          # relationships are properly set
-          expect(post.user_id).to eq user.id
-          expect(post.project_id).to eq project.id
-
-          # correct number of mentions was generated
-          expect(PostUserMention.count).to eq 2
-
-          # no notifications were sent or created
-          expect(Notification.pending.count).to eq 0
-
-          # no mails were sent
-          expect(ActionMailer::Base.deliveries.count).to eq 0
-        end
-      end
-
-      context "when requesting an actual save" do
+      context "when the attributes are valid" do
         it "creates a published post" do
           make_request_with_sidekiq_inline params
 
@@ -251,8 +212,6 @@ describe "Posts API" do
           expect(post.issue?).to be true
           expect(post.body).to eq "<p>@#{mentioned_1.username} @#{mentioned_2.username}</p>"
           expect(post.markdown).to eq "@#{mentioned_1.username} @#{mentioned_2.username}"
-          expect(post.body_preview).to eq "<p>@#{mentioned_1.username} @#{mentioned_2.username}</p>"
-          expect(post.markdown_preview).to eq "@#{mentioned_1.username} @#{mentioned_2.username}"
 
           # relationships are properly set
           expect(post.user_id).to eq user.id
@@ -274,7 +233,7 @@ describe "Posts API" do
           {
             data: {
               attributes: {
-                title: nil, markdown_preview: nil
+                title: nil, markdown: nil
               },
               relationships: {
                 project: { data: { id: project.id, type: "projects" } }
@@ -324,8 +283,9 @@ describe "Posts API" do
             type: "posts",
             attributes: {
               title: "Edited title",
-              markdown_preview: "@#{mentioned_1.username} @#{mentioned_2.username}",
-              post_type: "task"
+              markdown: "@#{mentioned_1.username} @#{mentioned_2.username}",
+              post_type: "task",
+              state: "edited"
             },
             relationships: {
               project: { data: { id: project.id, type: "projects" } }
@@ -349,76 +309,29 @@ describe "Posts API" do
         end
       end
 
-      context "when post is a draft" do
-        let(:post) { create :post, :draft, project: project, user: user, post_type: "issue" }
-
-        before do
-          ActionMailer::Base.deliveries.clear
-        end
-
-        context "when requesting a preview" do
-          before do
-            params[:data][:attributes][:preview] = true
-          end
-
-          it "updates the draft" do
-            make_request_with_sidekiq_inline params
-
-            # response is correct
-            expect(last_response.status).to eq 200
-            expect(json).to serialize_object(post.reload).with(PostSerializer)
-
-            # state is proper
-            expect(post.draft?).to be true
-
-            # attributes are properly set
-            expect(post.title).to eq "Edited title"
-            # post_type parameter was accepted
-            expect(post.task?).to be true
-            expect(post.body).to be_nil
-            expect(post.markdown).to be_nil
-            expect(post.body_preview).
-              to eq "<p>@#{mentioned_1.username} @#{mentioned_2.username}</p>"
-            expect(post.markdown_preview).to eq "@#{mentioned_1.username} @#{mentioned_2.username}"
-
-            # post type was set
-            expect(post.post_type).to eq "task"
-
-            # relationships are properly set
-            expect(post.user_id).to eq user.id
-            expect(post.project_id).to eq project.id
-
-            # correct number of mentions was generated
-            expect(PostUserMention.count).to eq 2
-
-            # no notifications were sent or created
-            expect(Notification.pending.count).to eq 0
-
-            # no mails were sent
-            expect(ActionMailer::Base.deliveries.count).to eq 0
-          end
-        end
+      context "when post is published" do
+        let(:post) { create :post, project: project, user: user, post_type: :issue }
 
         context "when requesting an actual save" do
-          it "updates and publishes post" do
+          it "updates and post and sets it to edited state" do
             make_request_with_sidekiq_inline params
+
+            post.reload
 
             # response is correct
             expect(last_response.status).to eq 200
             expect(json).to serialize_object(post.reload).with(PostSerializer)
 
             # state is proper
-            expect(post.published?).to be true
+            expect(post.edited?).to be true
 
             # attributes are properly set
             expect(post.title).to eq "Edited title"
-            # post_type parameter was accepted
-            expect(post.task?).to be true
             expect(post.body).to eq "<p>@#{mentioned_1.username} @#{mentioned_2.username}</p>"
             expect(post.markdown).to eq "@#{mentioned_1.username} @#{mentioned_2.username}"
-            expect(post.body_preview).
-              to eq "<p>@#{mentioned_1.username} @#{mentioned_2.username}</p>"
-            expect(post.markdown_preview).to eq "@#{mentioned_1.username} @#{mentioned_2.username}"
+
+            # post_type parameter was accepted
+            expect(post.task?).to be true
 
             # relationships are properly set
             expect(post.user_id).to eq user.id
@@ -436,65 +349,21 @@ describe "Posts API" do
         end
       end
 
-      context "when post is published" do
-        let(:post) { create :post, :published, project: project, user: user, post_type: :issue }
-
-        context "when requesting a preview" do
-          before do
-            params[:data][:attributes][:preview] = true
-          end
-
-          it "updates the published post" do
-            make_request_with_sidekiq_inline params
-
-            # post_type parameter was ignored
-            expect(post.issue?).to be true
-
-            # response is correct
-            expect(last_response.status).to eq 200
-            expect(json).to serialize_object(post.reload).with(PostSerializer)
-
-            # state is proper
-            expect(post.published?).to be true
-          end
-        end
-
-        context "when requesting an actual save" do
-          it "updates and post and sets it to edited state" do
-            params[:data][:attributes][:publish] = true
-            make_request_with_sidekiq_inline params
-
-            # post_type parameter was ignored
-            expect(post.task?).to be false
-
-            # response is correct
-            expect(last_response.status).to eq 200
-            expect(json).to serialize_object(post.reload).with(PostSerializer)
-
-            # state is proper
-            expect(post.edited?).to be true
-          end
-        end
-      end
-
-      context "when post exists and markdown_preview param is an empty string" do
-        let(:post) { create :post, :draft, project: project, user: user, post_type: "issue" }
+      context "when post exists and markdown param is an empty string" do
+        let(:post) { create :post, project: project, user: user, post_type: "issue" }
 
         before do
-          params[:data][:attributes][:preview] = true
-          params[:data][:attributes][:markdown_preview] = ""
+          params[:data][:attributes][:markdown] = ""
         end
 
-        it "overwrites the body_preview with new markdown data" do
+        it "does not overwrite the markdown or body" do
           make_request_with_sidekiq_inline params
-          expect(last_response.status).to eq 200
+          expect(last_response.status).to eq 422
+          expect(json).to be_a_valid_json_api_validation_error
 
           post.reload
-          expect(post.markdown_preview).to eq ""
-          expect(post.body_preview).to eq ""
-
-          expect(json.data.attributes.markdown_preview).to eq ""
-          expect(json.data.attributes.body_preview).to eq ""
+          expect(post.markdown).to_not eq ""
+          expect(post.body).to_not eq ""
         end
       end
     end

--- a/spec/requests/api/preview_user_mentions_spec.rb
+++ b/spec/requests/api/preview_user_mentions_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe "PreviewUserMentions API" do
+  context "GET /preview_user_mentions/" do
+    def make_request_for_preview(preview)
+      get "#{host}/preview_user_mentions/", preview_id: preview.id
+    end
+
+    let(:preview_a) { create(:preview) }
+    let(:preview_b) { create(:preview) }
+
+    before do
+      create_list(:preview_user_mention, 4, preview: preview_a)
+      create_list(:preview_user_mention, 1, preview: preview_b)
+    end
+
+    it "fetches mentions of specified status for specified post" do
+      make_request_for_preview(preview_a)
+      expect(last_response.status).to eq 200
+      expect(json).
+        to serialize_collection(preview_a.preview_user_mentions.all).
+        with(PreviewUserMentionSerializer)
+
+      make_request_for_preview(preview_b)
+      expect(last_response.status).to eq 200
+      expect(json).
+        to serialize_collection(preview_b.preview_user_mentions.all).
+        with(PreviewUserMentionSerializer)
+    end
+  end
+end

--- a/spec/requests/api/previews_spec.rb
+++ b/spec/requests/api/previews_spec.rb
@@ -1,0 +1,93 @@
+require "rails_helper"
+
+describe "Previews API" do
+  feature "cors" do
+    it "should be supported for POST" do
+      post "#{host}/previews", nil, "HTTP_ORIGIN" => "*"
+      expect(last_response).to have_proper_cors_headers
+
+      cors_options("previews", :post)
+      expect(last_response).to have_proper_preflight_options_response_headers
+    end
+
+    it "should be supported for PATCH" do
+      post "#{host}/previews", nil, "HTTP_ORIGIN" => "*"
+      expect(last_response).to have_proper_cors_headers
+
+      cors_options("previews", :patch)
+      expect(last_response).to have_proper_preflight_options_response_headers
+    end
+  end
+
+  context "POST /previews" do
+    context "when unauthenticated" do
+      it "responds with a proper 401" do
+        post "#{host}/previews", data: { type: "previews" }
+        expect(last_response.status).to eq 401
+        expect(json).to be_a_valid_json_api_error.with_id "NOT_AUTHORIZED"
+      end
+    end
+
+    context "when authenticated" do
+      let(:user) { create :user, password: "password" }
+      let(:token) { authenticate email: user.email, password: "password" }
+
+      let(:mentioned_1) { create(:user) }
+      let(:mentioned_2) { create(:user) }
+
+      def make_request(params)
+        authenticated_post "/previews", params, token
+      end
+
+      let(:params) do
+        {
+          data: {
+            type: "previews",
+            attributes: {
+              markdown: "@#{mentioned_1.username} @#{mentioned_2.username}"
+            }
+          }
+        }
+      end
+
+      context "when the attributes are valid" do
+        it "creates a published preview" do
+          make_request params
+
+          preview = Preview.last
+
+          # response is correct
+          expect(json).to serialize_object(preview).with(PreviewSerializer)
+
+          # attributes are properly set
+          expect(preview.body).to eq "<p>@#{mentioned_1.username} @#{mentioned_2.username}</p>"
+          expect(preview.markdown).to eq "@#{mentioned_1.username} @#{mentioned_2.username}"
+
+          # relationships are properly set
+          expect(preview.user_id).to eq user.id
+
+          # a mention was generated for each mentioned user
+          expect(PreviewUserMention.count).to eq 2
+        end
+      end
+
+      context "when the attributes are invalid" do
+        let(:invalid_attributes) do
+          {
+            data: {
+              attributes: {
+                title: "", markdown: ""
+              }
+            }
+          }
+        end
+
+        it "responds with a 422 validation error" do
+          make_request invalid_attributes
+          expect(last_response.status).to eq 422
+          expect(json).to be_a_valid_json_api_validation_error
+        end
+      end
+    end
+  end
+end

--- a/spec/serializers/comment_serializer_spec.rb
+++ b/spec/serializers/comment_serializer_spec.rb
@@ -2,26 +2,22 @@
 #
 # Table name: comments
 #
-#  id               :integer          not null, primary key
-#  body             :text
-#  user_id          :integer          not null
-#  post_id          :integer          not null
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  markdown         :text
-#  aasm_state       :string
-#  body_preview     :text
-#  markdown_preview :text
+#  id         :integer          not null, primary key
+#  body       :text
+#  user_id    :integer          not null
+#  post_id    :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  markdown   :text
+#  aasm_state :string
 #
 
 require "rails_helper"
 
-describe CommentSerializer, :type => :serializer do
-
+describe CommentSerializer, type: :serializer do
   # We only use before all here because we know the context does not change
   before :all do
     @comment = create(:comment, body: "Comment body", post: create(:post))
-    @comment.publish
     @comment.edit
   end
 
@@ -62,16 +58,6 @@ describe CommentSerializer, :type => :serializer do
       it "has 'markdown'" do
         expect(subject["markdown"]).not_to be_nil
         expect(subject["markdown"]).to eql resource.markdown
-      end
-
-      it "has a 'body_preview'" do
-        expect(subject["body_preview"]).not_to be_nil
-        expect(subject["body_preview"]).to eql resource.body_preview
-      end
-
-      it "has 'markdown_preview'" do
-        expect(subject["markdown_preview"]).not_to be_nil
-        expect(subject["markdown_preview"]).to eql resource.markdown_preview
       end
 
       it "has a 'state'" do

--- a/spec/serializers/comment_user_mention_serializer_spec.rb
+++ b/spec/serializers/comment_user_mention_serializer_spec.rb
@@ -11,7 +11,6 @@
 #  end_index   :integer          not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  status      :string           default("preview"), not null
 #
 
 require "rails_helper"
@@ -52,11 +51,6 @@ describe CommentUserMentionSerializer, type: :serializer do
 
       it "has 'indices'" do
         expect(subject["indices"]).to eql resource.indices
-      end
-
-      it "has 'status'" do
-        expect(subject["status"]).not_to be_nil
-        expect(subject["status"]).to eql resource.status
       end
     end
 

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -16,8 +16,6 @@
 #  number           :integer
 #  aasm_state       :string
 #  comments_count   :integer          default(0)
-#  body_preview     :text
-#  markdown_preview :text
 #
 
 require "rails_helper"
@@ -34,7 +32,6 @@ describe PostSerializer, type: :serializer do
       number: 1
     )
 
-    @post.publish!
     @post.edit!
 
     create_list(:comment, 2, post: @post)
@@ -85,16 +82,6 @@ describe PostSerializer, type: :serializer do
       it "has 'markdown'" do
         expect(subject["markdown"]).not_to be_nil
         expect(subject["markdown"]).to eql resource.markdown
-      end
-
-      it "has a 'body_preview'" do
-        expect(subject["body_preview"]).not_to be_nil
-        expect(subject["body_preview"]).to eql resource.body_preview
-      end
-
-      it "has 'markdown_preview'" do
-        expect(subject["markdown_preview"]).not_to be_nil
-        expect(subject["markdown_preview"]).to eql resource.markdown_preview
       end
 
       it "has a 'status'" do

--- a/spec/serializers/post_serializer_without_includes_spec.rb
+++ b/spec/serializers/post_serializer_without_includes_spec.rb
@@ -1,9 +1,8 @@
 require "rails_helper"
 
-describe PostSerializerWithoutIncludes, :type => :serializer do
-
+describe PostSerializerWithoutIncludes, type: :serializer do
   context "individual resource representation" do
-    let(:resource) {
+    let(:resource) do
       post = create(:post,
         title: "Post title",
         user: create(:user),
@@ -11,12 +10,11 @@ describe PostSerializerWithoutIncludes, :type => :serializer do
         body: "Some body",
         number: 1)
 
-      post.publish!
       post.edit!
 
       create_list(:comment, 10, post: post)
       post.reload
-    }
+    end
 
     let(:serializer) { PostSerializerWithoutIncludes.new(resource) }
     let(:serialization) { ActiveModel::Serializer::Adapter.create(serializer) }
@@ -56,16 +54,6 @@ describe PostSerializerWithoutIncludes, :type => :serializer do
       it "has 'markdown'" do
         expect(subject["markdown"]).not_to be_nil
         expect(subject["markdown"]).to eql resource.markdown
-      end
-
-      it "has a 'body_preview'" do
-        expect(subject["body_preview"]).not_to be_nil
-        expect(subject["body_preview"]).to eql resource.body_preview
-      end
-
-      it "has 'markdown_preview'" do
-        expect(subject["markdown_preview"]).not_to be_nil
-        expect(subject["markdown_preview"]).to eql resource.markdown_preview
       end
 
       it "has a 'status'" do

--- a/spec/serializers/post_user_mention_serializer_spec.rb
+++ b/spec/serializers/post_user_mention_serializer_spec.rb
@@ -10,7 +10,6 @@
 #  end_index   :integer          not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  status      :string           default("preview"), not null
 #
 
 require "rails_helper"
@@ -51,11 +50,6 @@ describe PostUserMentionSerializer, type: :serializer do
 
       it "has 'indices'" do
         expect(subject["indices"]).to eql resource.indices
-      end
-
-      it "has 'status'" do
-        expect(subject["status"]).not_to be_nil
-        expect(subject["status"]).to eql resource.status
       end
     end
 

--- a/spec/workers/generate_comment_user_notifications_worker_spec.rb
+++ b/spec/workers/generate_comment_user_notifications_worker_spec.rb
@@ -1,29 +1,19 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe GenerateCommentUserNotificationsWorker do
-
-  let(:draft_comment) { create(:comment, :draft, :with_user_mentions, mention_count: 4) }
   let(:published_comment) { create(:comment, :published, :with_user_mentions, mention_count: 4) }
 
   context "when there are no pre-existing notifications" do
-    context "when the comment is a draft" do
-      it "creates no notifications" do
-        expect { GenerateCommentUserNotificationsWorker.new.perform(draft_comment.id) }.not_to change { ActionMailer::Base.deliveries.count }
-      end
-
-      it "sends no emails" do
-        expect { GenerateCommentUserNotificationsWorker.new.perform(draft_comment.id) }.not_to change { Notification.sent.count }
-      end
+    it "creates correct number of notifications" do
+      expect do
+        GenerateCommentUserNotificationsWorker.new.perform(published_comment.id)
+      end.to change { ActionMailer::Base.deliveries.count }.by 4
     end
 
-    context "when the comment is published" do
-      it "creates correct number of notifications" do
-        expect { GenerateCommentUserNotificationsWorker.new.perform(published_comment.id) }.to change { ActionMailer::Base.deliveries.count }.by 4
-      end
-
-      it "sends correct number of emails" do
-        expect { GenerateCommentUserNotificationsWorker.new.perform(published_comment.id) }.to change { Notification.sent.count }.by 4
-      end
+    it "sends correct number of emails" do
+      expect do
+        GenerateCommentUserNotificationsWorker.new.perform(published_comment.id)
+      end.to change { Notification.sent.count }.by 4
     end
   end
 
@@ -34,11 +24,15 @@ describe GenerateCommentUserNotificationsWorker do
     end
 
     it "creates correct number of notifications" do
-      expect { GenerateCommentUserNotificationsWorker.new.perform(published_comment.id) }.to change { ActionMailer::Base.deliveries.count }.by 4
+      expect do
+        GenerateCommentUserNotificationsWorker.new.perform(published_comment.id)
+      end.to change { ActionMailer::Base.deliveries.count }.by 4
     end
 
     it "sends correct number of emails" do
-      expect { GenerateCommentUserNotificationsWorker.new.perform(published_comment.id) }.to change { Notification.sent.count }.by 4
+      expect do
+        GenerateCommentUserNotificationsWorker.new.perform(published_comment.id)
+      end.to change { Notification.sent.count }.by 4
     end
   end
 end

--- a/spec/workers/generate_post_user_notifications_worker_spec.rb
+++ b/spec/workers/generate_post_user_notifications_worker_spec.rb
@@ -1,29 +1,19 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe GeneratePostUserNotificationsWorker do
-
-  let(:draft_post) { create(:post, :draft, :with_user_mentions, mention_count: 4) }
   let(:published_post) { create(:post, :published, :with_user_mentions, mention_count: 4) }
 
   context "when there are no pre-existing notifications" do
-    context "when the post is a draft" do
-      it "creates no notifications" do
-        expect { GeneratePostUserNotificationsWorker.new.perform(draft_post.id) }.to_not change { ActionMailer::Base.deliveries.count }
-      end
-
-      it "sends no emails" do
-        expect { GeneratePostUserNotificationsWorker.new.perform(draft_post.id) }.to_not change { Notification.sent.count }
-      end
+    it "creates correct number of notifications" do
+      expect do
+        GeneratePostUserNotificationsWorker.new.perform(published_post.id)
+      end.to change { ActionMailer::Base.deliveries.count }.by 4
     end
 
-    context "when the post is published" do
-      it "creates correct number of notifications" do
-        expect { GeneratePostUserNotificationsWorker.new.perform(published_post.id) }.to change { ActionMailer::Base.deliveries.count }.by 4
-      end
-
-      it "sends correct number of emails" do
-        expect { GeneratePostUserNotificationsWorker.new.perform(published_post.id) }.to change { Notification.sent.count }.by 4
-      end
+    it "sends correct number of emails" do
+      expect do
+        GeneratePostUserNotificationsWorker.new.perform(published_post.id)
+      end.to change { Notification.sent.count }.by 4
     end
   end
 
@@ -34,11 +24,15 @@ describe GeneratePostUserNotificationsWorker do
     end
 
     it "creates correct number of notifications" do
-      expect { GeneratePostUserNotificationsWorker.new.perform(published_post.id) }.to change { ActionMailer::Base.deliveries.count }.by 4
+      expect do
+        GeneratePostUserNotificationsWorker.new.perform(published_post.id)
+      end.to change { ActionMailer::Base.deliveries.count }.by 4
     end
 
     it "sends correct number of emails" do
-      expect { GeneratePostUserNotificationsWorker.new.perform(published_post.id) }.to change { Notification.sent.count }.by 4
+      expect do
+        GeneratePostUserNotificationsWorker.new.perform(published_post.id)
+      end.to change { Notification.sent.count }.by 4
     end
   end
 end


### PR DESCRIPTION
This closes #314.

This adds a `/previews` endpoint where you can create a `Preview` model which `has_many :preview_user_mentions`. It takes in markdown and renders out HTML.

We're getting rid of the `_preview` fields on `Post` and `Comment`, as well as the concept of draft states.

The assumption here is that the client requests a `Preview` for any kind of record: it doesn't matter what that record is. Instead, we just render mentions and the filter the markdown through a pipeline.

Thus, previews are completely isolated from the behavior of objects we might want previews for.

This will allow the client to request any number of markdown-ified previews it wants. We could modify the preview to not generate mentions if we want, or do other custom things dependent on the preview. We could also add a polymorphic relationship and track what we generated a preview for.

This can't really be merged without a sister PR on the Ember side to make this work.
