### PR TITLE
Add Heroku binstubs

### DIFF
--- a/bin/development
+++ b/bin/development
@@ -1,0 +1,2 @@
+#!/bin/sh
+HEROKU_APP=code-corps-development HKAPP=code-corps-development exec "${HEROKU_COMMAND:-heroku}" "$@"

--- a/bin/production
+++ b/bin/production
@@ -1,0 +1,2 @@
+#!/bin/sh
+HEROKU_APP=code-corps HKAPP=code-corps exec "${HEROKU_COMMAND:-heroku}" "$@"

--- a/bin/staging
+++ b/bin/staging
@@ -1,0 +1,2 @@
+#!/bin/sh
+HEROKU_APP=code-corps-staging HKAPP=code-corps-staging exec "${HEROKU_COMMAND:-heroku}" "$@"


### PR DESCRIPTION
This update adds Heroku [binstubs](https://github.com/tpope/heroku-binstubs), simple wrappers around the `heroku` command. This saves an inordinate amount of keystrokes by allowing you run any heroku command (`info`, `run`, etc) by simply typing `staging run console` instead of `heroku run console --app  code-corps-staging`. 

Binstubs have been created for `development`, `staging` and `production`.

See https://github.com/tpope/heroku-binstubs for additional info.
