### PR TITLE
Add open and closed post counts to project

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "aasm"
 gem "analytics-ruby", require: "segment"
 gem "aws-sdk"
 gem "clearance"
+gem "counter_culture"
 gem "doorkeeper"
 gem "faraday"
 gem "github-markdown"
@@ -65,6 +66,7 @@ group :test do
   gem "pusher-fake"
   gem "rspec-sidekiq"
   gem "shoulda-matchers", "3.0.1" # locked due to https://github.com/thoughtbot/shoulda-matchers/issues/880
+  gem "test_after_commit"
   gem "vcr"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,9 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
+    after_commit_action (1.0.1)
+      activerecord (>= 3.0.0)
+      activesupport (>= 3.0.0)
     analytics-ruby (2.0.13)
     annotate (2.7.0)
       activerecord (>= 3.2, < 6.0)
@@ -98,6 +101,10 @@ GEM
     concurrent-ruby (1.0.0)
     connection_pool (2.2.0)
     cookiejar (0.3.0)
+    counter_culture (0.2.1)
+      activerecord (>= 3.0.0)
+      activesupport (>= 3.0.0)
+      after_commit_action (~> 1.0.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     daemons (1.2.3)
@@ -319,6 +326,8 @@ GEM
       sprockets (>= 3.0.0)
     strip_attributes (1.8.0)
       activemodel (>= 3.0, < 6.0)
+    test_after_commit (1.1.0)
+      activerecord (>= 3.2)
     thin (1.6.4)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -350,6 +359,7 @@ DEPENDENCIES
   capybara
   clearance
   codeclimate-test-reporter
+  counter_culture
   database_cleaner
   doorkeeper
   dotenv-rails
@@ -391,6 +401,7 @@ DEPENDENCIES
   sinatra
   spring
   strip_attributes
+  test_after_commit
   vcr
   webmock
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -35,6 +35,13 @@ class Post < ActiveRecord::Base
 
   acts_as_sequenced scope: :project_id, column: :number
 
+  counter_culture :project,
+                  column_name: proc { |model| "#{model.status}_posts_count" },
+                  column_names: {
+                    ["posts.status = ?", "open"] => "open_posts_count",
+                    ["posts.status = ?", "closed"] => "closed_posts_count"
+                  }
+
   validates :body, presence: true
   validates :markdown, presence: true
   validates :post_type, presence: true

--- a/circle.yml
+++ b/circle.yml
@@ -1,13 +1,16 @@
+machine:
+  services:
+    - elasticsearch
 deployment:
-    staging:
-      branch: develop
-      commands:
-        - git push git@heroku.com:code-corps-development.git $CIRCLE_SHA1:master
-        - heroku run rake db:migrate --app code-corps-development
-        - git push git@heroku.com:code-corps-staging.git $CIRCLE_SHA1:master
-        - heroku run rake db:migrate --app code-corps-staging
-    production:
-      branch: master
-      commands:
-        - git push git@heroku.com:code-corps.git $CIRCLE_SHA1:master
-        - heroku run rake db:migrate --app code-corps
+  staging:
+    branch: develop
+    commands:
+      - git push git@heroku.com:code-corps-development.git $CIRCLE_SHA1:master
+      - heroku run rake db:migrate --app code-corps-development
+      - git push git@heroku.com:code-corps-staging.git $CIRCLE_SHA1:master
+      - heroku run rake db:migrate --app code-corps-staging
+  production:
+    branch: master
+    commands:
+      - git push git@heroku.com:code-corps.git $CIRCLE_SHA1:master
+      - heroku run rake db:migrate --app code-corps

--- a/db/migrate/20160623044025_add_open_and_closed_posts_count_to_projects.rb
+++ b/db/migrate/20160623044025_add_open_and_closed_posts_count_to_projects.rb
@@ -1,0 +1,6 @@
+class AddOpenAndClosedPostsCountToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :open_posts_count, :integer, null: false, default: 0
+    add_column :projects, :closed_posts_count, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160621203648) do
+ActiveRecord::Schema.define(version: 20160623044025) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -256,6 +256,8 @@ ActiveRecord::Schema.define(version: 20160621203648) do
     t.string   "aasm_state"
     t.text     "long_description_body"
     t.text     "long_description_markdown"
+    t.integer  "open_posts_count",          default: 0, null: false
+    t.integer  "closed_posts_count",        default: 0, null: false
   end
 
   add_index "projects", ["organization_id"], name: "index_projects_on_organization_id", using: :btree

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -141,6 +141,69 @@ describe Post, type: :model do
     end
   end
 
+  describe "counter caches" do
+    context "on #project" do
+      let(:post) { create(:post) }
+      let(:project) { post.project }
+
+      context "with an 'open' status" do
+        before do
+          post.open!
+          project.reload
+        end
+
+        context "when creating" do
+          it "increments the open posts counter" do
+            expect(project.open_posts_count).to eq(1)
+          end
+        end
+
+        context "when destroying" do
+          it "decrements the open posts counter" do
+            expect { post.destroy! && project.reload }.
+              to change(project, :open_posts_count).from(1).to(0)
+          end
+        end
+
+        context "when changing" do
+          it "decrements the open posts counter" do
+            post.status = "closed"
+            expect { post.save! && project.reload }.
+              to change(project, :open_posts_count).from(1).to(0)
+          end
+        end
+      end
+
+      context "with a 'closed' status" do
+        before do
+          post.closed!
+          project.reload
+        end
+
+        describe "when creating" do
+          it "increments the closed posts counter" do
+            expect(project.closed_posts_count).to eq(1)
+          end
+        end
+
+        describe "when destroying" do
+          it "decrements the closed posts counter" do
+            expect { post.destroy! && project.reload }.
+              to change(project, :closed_posts_count).from(1).to(0)
+          end
+        end
+
+        describe "when changing" do
+          it "decrements the closed posts counter" do
+            post.status = "open"
+            expect { post.save! && project.reload }.
+              to change(project, :closed_posts_count).from(1).to(0)
+          end
+        end
+      end
+    end
+  end
+
   describe "#save" do
     it "renders markdown to body" do
       post = build(:post, markdown: "# Hello World\n\nHello, world.")

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,7 +41,7 @@ ActiveRecord::Migration.maintain_test_schema!
 
 VCR.configure do |config|
   # Allow results to reported to codeclimate, bypassing VCR
-  config.ignore_hosts "codeclimate.com"
+  config.ignore_hosts "codeclimate.com", "localhost"
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
A project should be able to return the number of open posts as well as the number of closed posts. This update adds two counter caches to the project model: 
- `open_posts_count` – The number of open posts for the project.
- `closed_posts_count` – The number of closed posts for the project.

The [`test_after_commit`](https://github.com/grosser/test_after_commit) gem has also been added to the `test` group, and is necessary because transactional fixtures are enabled and counter caches are updated in an `after_commit` callback. See [magnusvk/counter_culture](https://github.com/magnusvk/counter_culture#a-note-on-testing) for more info. This will no longer be needed in Rails 5: [rails/rails/pull/18458](https://github.com/rails/rails/pull/18458).

To update existing counters, the following can be run:

``` ruby
Post.counter_culture_fix_counts
# https://github.com/magnusvk/counter_culture#manually-populating-counter-cache-values
```

Closes #323
