### PR TITLE
Enabled endpoint and coalesced id filter on GET /organizations

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -18,6 +18,12 @@
 class OrganizationsController < ApplicationController
   before_action :doorkeeper_authorize!, only: [:create, :update]
 
+  def index
+    authorize Organization
+    organizations = Organization.includes([:projects, :members]).find(id_params)
+    render json: organizations
+  end
+
   def show
     organization = Organization.find(params[:id])
 
@@ -57,6 +63,10 @@ class OrganizationsController < ApplicationController
   end
 
   private
+
+    def id_params
+      params.require(:filter).require(:id).split(",")
+    end
 
     def create_params
       parse_params(params, only: [:name, :slug, :description, :base64_icon_data])

--- a/app/policies/organization_policy.rb
+++ b/app/policies/organization_policy.rb
@@ -6,6 +6,10 @@ class OrganizationPolicy
     @organization = organization
   end
 
+  def index?
+    true
+  end
+
   def show?
     true
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
 
     resources :github_repositories, only: [:create]
 
-    resources :organizations, only: [:show, :create, :update] do
+    resources :organizations, only: [:index, :show, :create, :update] do
       get "memberships", to: "organization_memberships#index"
     end
     resources :organization_memberships, only: [:show, :create, :update, :destroy]

--- a/spec/policies/organization_policy_spec.rb
+++ b/spec/policies/organization_policy_spec.rb
@@ -41,6 +41,12 @@ describe OrganizationPolicy do
     @site_admin = create(:user, admin: true)
   end
 
+  permissions :index? do
+    it "can be viewed by anyone" do
+      expect(subject).to permit(nil, Organization)
+    end
+  end
+
   permissions :show? do
     context "as a logged out user" do
       it "can view all organizations" do


### PR DESCRIPTION
Part of requirements for #343

We didn't have the route here at all. The reason I think we need the endpoint is we will likely have (or possibly already do) a scenario where wi get a user's organization memberships, and then want to get the organizations as well.

Since this reason is the only reason we need the endpoint, I made sure the id filter is required.
