### PR TITLE
Stub AWS responses

### DIFF
--- a/spec/support/aws.rb
+++ b/spec/support/aws.rb
@@ -1,0 +1,1 @@
+Aws.config[:stub_responses] = true


### PR DESCRIPTION
To partially address #351, this change stubs AWS responses so that fake data is generated and no HTTP requests are made.

cc: @JoshSmith 
