### PR TITLE
Speed up and backfill policy specs

### DIFF
--- a/app/policies/comment_image_policy.rb
+++ b/app/policies/comment_image_policy.rb
@@ -14,10 +14,11 @@ class CommentImagePolicy
     return false unless comment.user_id == user.id
 
     # Can create comments for any user
-    return true
+    true
   end
 
   private
+
     def comment
       @comment ||= comment_image.comment
     end

--- a/spec/policies/category_policy_spec.rb
+++ b/spec/policies/category_policy_spec.rb
@@ -4,9 +4,9 @@ describe CategoryPolicy do
   subject { described_class }
 
   before do
-    @category = create(:category)
-    @regular_user = create(:user)
-    @site_admin = create(:user, admin: true)
+    @category = build_stubbed(:category)
+    @regular_user = build_stubbed(:user)
+    @site_admin = build_stubbed(:user, admin: true)
   end
 
   permissions :index?, :show? do

--- a/spec/policies/comment_image_policy_spec.rb
+++ b/spec/policies/comment_image_policy_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+describe CommentImagePolicy do
+  subject { described_class }
+
+  let(:comment) { build_stubbed(:comment) }
+
+  let(:gif_string) do
+    open(
+      File.open(
+        "#{Rails.root}/spec/sample_data/base64_images/gif.txt", "r"
+      ),
+      &:read
+    )
+  end
+
+  let(:comment_image) do
+    build_stubbed(
+      :comment_image,
+      :with_s3_image,
+      filename: "jake.gif",
+      base64_photo_data: gif_string,
+      comment: comment,
+      user: user
+    )
+  end
+
+  let(:user) { build_stubbed(:user) }
+
+  permissions :create? do
+    it "is not permitted when no user is present" do
+      expect(subject).not_to permit(nil, comment_image)
+    end
+
+    it "is not permitted when not the same user" do
+      expect(subject).not_to permit(user, comment_image)
+    end
+
+    it "is permitted when comment belongs to the user" do
+      expect(subject).to permit(comment.user, comment_image)
+    end
+  end
+end

--- a/spec/policies/comment_policy_spec.rb
+++ b/spec/policies/comment_policy_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 
 describe CommentPolicy do
   subject { described_class }
-  let(:project) { create(:project) }
-  let(:author) { create(:user) }
-  let(:other_user) { create(:user) }
-  let(:comment) { create(:comment, user: author) }
+  let(:author) { build_stubbed(:user) }
+  let(:comment) { build_stubbed(:comment, user: author) }
+  let(:other_user) { build_stubbed(:user) }
+  let(:project) { build_stubbed(:project) }
 
   permissions :post_index? do
     it "is permited for anyone" do

--- a/spec/policies/github_repository_policy_spec.rb
+++ b/spec/policies/github_repository_policy_spec.rb
@@ -1,52 +1,70 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe GithubRepositoryPolicy do
-
   subject { described_class }
 
+  let(:admin) { build_stubbed(:user) }
+  let(:contributor) { build_stubbed(:user) }
+  let(:github_repository) { build_stubbed(:github_repository, project: project) }
+  let(:organization) { build_stubbed(:organization) }
+  let(:owner) { build_stubbed(:user) }
+  let(:pending_user) { build_stubbed(:user) }
+  let(:project) { build_stubbed(:project, organization: organization) }
+  let(:unassociated_user) { build_stubbed(:user) }
+
   before do
-    organization = create(:organization)
-    project = create(:project, organization: organization)
+    create(
+      :organization_membership,
+      member: pending_user,
+      organization: organization,
+      role: :pending
+    )
 
-    @github_repository = create(:github_repository, project: project)
+    create(
+      :organization_membership,
+      member: contributor,
+      organization: organization,
+      role: :contributor
+    )
 
-    @unassociated_user = create(:user)
+    create(
+      :organization_membership,
+      member: admin,
+      organization: organization,
+      role: :admin
+    )
 
-    @pending_user = create(:user)
-    create(:organization_membership, member: @pending_user, organization: organization, role: :pending)
-
-    @contributor = create(:user)
-    create(:organization_membership, member: @contributor, organization: organization, role: :contributor)
-
-    @admin = create(:user)
-    create(:organization_membership, member: @admin, organization: organization, role: :admin)
-
-    @owner = create(:user)
-    create(:organization_membership, member: @owner, organization: organization, role: :owner)
+    create(
+      :organization_membership,
+      member: owner,
+      organization: organization,
+      role: :owner
+    )
   end
 
   permissions :create? do
     it "is not permitted for unauthenticated users" do
-      expect(subject).not_to permit(nil, @github_repository)
+      expect(subject).not_to permit(nil, github_repository)
     end
 
     it "is not permitted for users not associated with the organization" do
-      expect(subject).not_to permit(@unassociated_user, @github_repository)
+      expect(subject).not_to permit(unassociated_user, github_repository)
     end
+
     it "is not permitted for users pending for organization membership" do
-      expect(subject).not_to permit(@pending_user, @github_repository)
+      expect(subject).not_to permit(pending_user, github_repository)
     end
 
     it "is not permitted for organization contributors" do
-      expect(subject).not_to permit(@contributor, @github_repository)
+      expect(subject).not_to permit(contributor, github_repository)
     end
 
     it "is permitted for organization admins" do
-      expect(subject).to permit(@admin, @github_repository)
+      expect(subject).to permit(admin, github_repository)
     end
 
     it "is permitted for organization onwers" do
-      expect(subject).to permit(@owner, @github_repository)
+      expect(subject).to permit(owner, github_repository)
     end
   end
 end

--- a/spec/policies/organization_membership_policy_spec.rb
+++ b/spec/policies/organization_membership_policy_spec.rb
@@ -3,19 +3,18 @@ require "rails_helper"
 describe OrganizationMembershipPolicy do
   subject { described_class }
 
+  let(:admin) { build(:user) }
+  let(:contributor) { build(:user) }
+  let(:non_member) { build_stubbed(:user) }
+  let(:owner) { build_stubbed(:user) }
+  let(:pending_user) { build(:user) }
   let(:test_organization) { create(:organization) }
 
-  let(:non_member) { create(:user) }
-  let(:pending_user) { create(:user) }
-  let(:contributor) { create(:user) }
-  let(:admin) { create(:user) }
-  let(:owner) { create(:user) }
-
-  def new_membership_for(member: create(:user), role: "pending", organization: test_organization)
+  def new_membership_for(member: build_stubbed(:user), role: "pending", organization: test_organization)
     build(:organization_membership, member: member, organization: organization, role: role)
   end
 
-  def create_membership_for(member: create(:user), role: "pending", organization: test_organization)
+  def create_membership_for(member: build_stubbed(:user), role: "pending", organization: test_organization)
     create(:organization_membership, member: member, organization: organization, role: role)
   end
 

--- a/spec/policies/organization_policy_spec.rb
+++ b/spec/policies/organization_policy_spec.rb
@@ -1,44 +1,41 @@
 require "rails_helper"
 
 describe OrganizationPolicy do
-
   subject { described_class }
 
+  let(:admin_user) { build_stubbed(:user) }
+  let(:contributor_user) { build_stubbed(:user) }
+  let(:organization) { build_stubbed(:organization) }
+  let(:owner_user) { build_stubbed(:user) }
+  let(:pending_user) { build_stubbed(:user) }
+  let(:site_admin) { build_stubbed(:user, admin: true) }
+  let(:unaffiliated_organization) { build_stubbed(:organization) }
+  let(:unaffiliated_user) { build_stubbed(:user) }
+
   before do
-    @organization = create(:organization)
-    @unaffiliated_organization = create(:organization)
-
-    @unaffiliated_user = create(:user)
-
     # Pending organization member
-    @pending_user = create(:user)
-    create(:organization_membership,
-           organization: @organization,
-           member: @pending_user,
-           role: "pending")
+    build_stubbed(:organization_membership,
+                  organization: organization,
+                  member: pending_user,
+                  role: "pending")
 
     # Contributor organization member
-    @contributor_user = create(:user)
-    create(:organization_membership,
-           organization: @organization,
-           member: @contributor_user,
-           role: "contributor")
+    build_stubbed(:organization_membership,
+                  organization: organization,
+                  member: contributor_user,
+                  role: "contributor")
 
     # Admin organization member
-    @admin_user = create(:user)
     create(:organization_membership,
-           organization: @organization,
-           member: @admin_user,
+           organization: organization,
+           member: admin_user,
            role: "admin")
 
     # Owner organization member
-    @owner_user = create(:user)
     create(:organization_membership,
-           organization: @organization,
-           member: @owner_user,
+           organization: organization,
+           member: owner_user,
            role: "owner")
-
-    @site_admin = create(:user, admin: true)
   end
 
   permissions :index? do
@@ -50,43 +47,43 @@ describe OrganizationPolicy do
   permissions :show? do
     context "as a logged out user" do
       it "can view all organizations" do
-        expect(subject).to permit(nil, @organization)
-        expect(subject).to permit(nil, @unaffiliated_organization)
+        expect(subject).to permit(nil, organization)
+        expect(subject).to permit(nil, unaffiliated_organization)
       end
     end
 
     context "as an unaffiliated user" do
       it "can view all organizations" do
-        expect(subject).to permit(@unaffiliated_user, @organization)
-        expect(subject).to permit(@unaffiliated_user, @unaffiliated_organization)
+        expect(subject).to permit(unaffiliated_user, organization)
+        expect(subject).to permit(unaffiliated_user, unaffiliated_organization)
       end
     end
 
     context "as a pending user" do
       it "can view all organizations" do
-        expect(subject).to permit(@pending_user, @organization)
-        expect(subject).to permit(@pending_user, @unaffiliated_organization)
+        expect(subject).to permit(pending_user, organization)
+        expect(subject).to permit(pending_user, unaffiliated_organization)
       end
     end
 
     context "as a contributor user" do
       it "can view all organizations" do
-        expect(subject).to permit(@contributor_user, @organization)
-        expect(subject).to permit(@contributor_user, @unaffiliated_organization)
+        expect(subject).to permit(contributor_user, organization)
+        expect(subject).to permit(contributor_user, unaffiliated_organization)
       end
     end
 
     context "as an admin user" do
       it "can view all organizations" do
-        expect(subject).to permit(@admin_user, @organization)
-        expect(subject).to permit(@admin_user, @unaffiliated_organization)
+        expect(subject).to permit(admin_user, organization)
+        expect(subject).to permit(admin_user, unaffiliated_organization)
       end
     end
 
     context "as an owner user" do
       it "can view all organizations" do
-        expect(subject).to permit(@owner_user, @organization)
-        expect(subject).to permit(@owner_user, @unaffiliated_organization)
+        expect(subject).to permit(owner_user, organization)
+        expect(subject).to permit(owner_user, unaffiliated_organization)
       end
     end
   end
@@ -100,43 +97,43 @@ describe OrganizationPolicy do
 
     context "as an unaffiliated user" do
       it "is not permitted to create/update organizations" do
-        expect(subject).to_not permit(@unaffiliated_user, @unaffiliated_organization)
+        expect(subject).to_not permit(unaffiliated_user, unaffiliated_organization)
       end
 
       it "is not permitted to create/update organizations" do
-        expect(subject).to_not permit(@unaffiliated_user, @organization)
+        expect(subject).to_not permit(unaffiliated_user, organization)
       end
     end
 
     context "as a pending user" do
       it "is not permitted to create/update organizations" do
-        expect(subject).to_not permit(@pending_user, @unaffiliated_organization)
+        expect(subject).to_not permit(pending_user, unaffiliated_organization)
       end
 
       it "is not permitted to create/update organizations" do
-        expect(subject).to_not permit(@pending_user, @organization)
+        expect(subject).to_not permit(pending_user, organization)
       end
     end
 
     context "as a contributor user" do
       it "is not permitted to create/update organizations" do
-        expect(subject).to_not permit(@contributor_user, @unaffiliated_organization)
+        expect(subject).to_not permit(contributor_user, unaffiliated_organization)
       end
 
       it "is not permitted to create/update organizations" do
-        expect(subject).to_not permit(@contributor_user, @organization)
+        expect(subject).to_not permit(contributor_user, organization)
       end
     end
 
     context "as an admin user" do
       it "is not permitted to create/update organizations" do
-        expect(subject).to_not permit(@admin_user, @unaffiliated_organization)
+        expect(subject).to_not permit(admin_user, unaffiliated_organization)
       end
     end
 
     context "as an owner user" do
       it "is not permitted to create/update organizations" do
-        expect(subject).to_not permit(@owner_user, @unaffiliated_organization)
+        expect(subject).to_not permit(owner_user, unaffiliated_organization)
       end
     end
   end
@@ -144,19 +141,19 @@ describe OrganizationPolicy do
   permissions :update? do
     context "as an admin user" do
       it "is permitted to update organizations" do
-        expect(subject).to permit(@admin_user, @organization)
+        expect(subject).to permit(admin_user, organization)
       end
     end
 
     context "as an owner user" do
       it "is permitted to update organizations" do
-        expect(subject).to permit(@owner_user, @organization)
+        expect(subject).to permit(owner_user, organization)
       end
     end
 
     context "as a site admin" do
       it "is not permitted to update organizations" do
-        expect(subject).to_not permit(@site_admin, @organization)
+        expect(subject).to_not permit(site_admin, organization)
       end
     end
   end
@@ -164,19 +161,19 @@ describe OrganizationPolicy do
   permissions :create? do
     context "as an admin user" do
       it "is not permitted to create organizations" do
-        expect(subject).to_not permit(@admin_user, @organization)
+        expect(subject).to_not permit(admin_user, organization)
       end
     end
 
     context "as an owner user" do
       it "is not permitted to create organizations" do
-        expect(subject).to_not permit(@owner_user, @organization)
+        expect(subject).to_not permit(owner_user, organization)
       end
     end
 
     context "as a site admin" do
       it "is permitted to create organizations" do
-        expect(subject).to permit(@site_admin, @organization)
+        expect(subject).to permit(site_admin, organization)
       end
     end
   end

--- a/spec/policies/post_policy_spec.rb
+++ b/spec/policies/post_policy_spec.rb
@@ -3,38 +3,32 @@ require "rails_helper"
 describe PostPolicy do
   subject { described_class }
 
-  let(:organization) { create(:organization) }
-  let(:project) { create(:project, organization: organization) }
-
-  let(:pending_user) { create(:user) }
-  let(:contributor_user) { create(:user) }
-  let(:admin_user) { create(:user) }
-  let(:owner_user) { create(:user) }
-
-  let(:idea_post) { create(:post, post_type: "idea", project: project) }
-  let(:task_post) { create(:post, post_type: "task", project: project) }
-  let(:issue_post) { create(:post, post_type: "issue", project: project) }
+  let(:admin_user) { build_stubbed(:user) }
+  let(:contributor_user) { build_stubbed(:user) }
+  let(:idea_post) { build_stubbed(:post, post_type: "idea", project: project) }
+  let(:issue_post) { build_stubbed(:post, post_type: "issue", project: project) }
+  let(:organization) { build(:organization) }
+  let(:owner_user) { build_stubbed(:user) }
+  let(:pending_user) { build_stubbed(:user) }
+  let(:project) { build(:project, organization: organization) }
+  let(:task_post) { build_stubbed(:post, post_type: "task", project: project) }
 
   before do
-    # Pending organization member
     create(:organization_membership,
            organization: organization,
            member: pending_user,
            role: "pending")
 
-    # Contributor organization member
     create(:organization_membership,
            organization: organization,
            member: contributor_user,
            role: "contributor")
 
-    # Admin organization member
     create(:organization_membership,
            organization: organization,
            member: admin_user,
            role: "admin")
 
-    # Owner organization member
     create(:organization_membership,
            organization: organization,
            member: owner_user,
@@ -100,26 +94,26 @@ describe PostPolicy do
       end
 
       it "is permitted to add an issue" do
-        post = create(:post,
-                      user: pending_user,
-                      post_type: "issue",
-                      project: project)
+        post = build_stubbed(:post,
+                             user: pending_user,
+                             post_type: "issue",
+                             project: project)
         expect(subject).to permit(pending_user, post)
       end
 
       it "is permitted to add an idea" do
-        post = create(:post,
-                      user: pending_user,
-                      post_type: "idea",
-                      project: project)
+        post = build_stubbed(:post,
+                             user: pending_user,
+                             post_type: "idea",
+                             project: project)
         expect(subject).to permit(pending_user, post)
       end
 
       it "is not permitted to add a task" do
-        post = create(:post,
-                      user: pending_user,
-                      post_type: "task",
-                      project: project)
+        post = build_stubbed(:post,
+                             user: pending_user,
+                             post_type: "task",
+                             project: project)
         expect(subject).not_to permit(pending_user, post)
       end
     end
@@ -132,26 +126,26 @@ describe PostPolicy do
       end
 
       it "is permitted to add an issue" do
-        post = create(:post,
-                      user: contributor_user,
-                      post_type: "issue",
-                      project: project)
+        post = build_stubbed(:post,
+                             user: contributor_user,
+                             post_type: "issue",
+                             project: project)
         expect(subject).to permit(contributor_user, post)
       end
 
       it "is permitted to add an idea" do
-        post = create(:post,
-                      user: contributor_user,
-                      post_type: "idea",
-                      project: project)
+        post = build_stubbed(:post,
+                             user: contributor_user,
+                             post_type: "idea",
+                             project: project)
         expect(subject).to permit(contributor_user, post)
       end
 
       it "is permitted to add a task" do
-        post = create(:post,
-                      user: contributor_user,
-                      post_type: "task",
-                      project: project)
+        post = build_stubbed(:post,
+                             user: contributor_user,
+                             post_type: "task",
+                             project: project)
         expect(subject).to permit(contributor_user, post)
       end
     end
@@ -164,26 +158,26 @@ describe PostPolicy do
       end
 
       it "is permitted to add an issue" do
-        post = create(:post,
-                      user: admin_user,
-                      post_type: "issue",
-                      project: project)
+        post = build_stubbed(:post,
+                             user: admin_user,
+                             post_type: "issue",
+                             project: project)
         expect(subject).to permit(admin_user, post)
       end
 
       it "is permitted to add an idea" do
-        post = create(:post,
-                      user: admin_user,
-                      post_type: "idea",
-                      project: project)
+        post = build_stubbed(:post,
+                             user: admin_user,
+                             post_type: "idea",
+                             project: project)
         expect(subject).to permit(admin_user, post)
       end
 
       it "is permitted to add a task" do
-        post = create(:post,
-                      user: admin_user,
-                      post_type: "task",
-                      project: project)
+        post = build_stubbed(:post,
+                             user: admin_user,
+                             post_type: "task",
+                             project: project)
         expect(subject).to permit(admin_user, post)
       end
     end
@@ -196,26 +190,26 @@ describe PostPolicy do
       end
 
       it "is permitted to add an issue" do
-        post = create(:post,
-                      user: owner_user,
-                      post_type: "issue",
-                      project: project)
+        post = build_stubbed(:post,
+                             user: owner_user,
+                             post_type: "issue",
+                             project: project)
         expect(subject).to permit(owner_user, post)
       end
 
       it "is permitted to add an idea" do
-        post = create(:post,
-                      user: owner_user,
-                      post_type: "idea",
-                      project: project)
+        post = build_stubbed(:post,
+                             user: owner_user,
+                             post_type: "idea",
+                             project: project)
         expect(subject).to permit(owner_user, post)
       end
 
       it "is permitted to add a task" do
-        post = create(:post,
-                      user: owner_user,
-                      post_type: "task",
-                      project: project)
+        post = build_stubbed(:post,
+                             user: owner_user,
+                             post_type: "task",
+                             project: project)
         expect(subject).to permit(owner_user, post)
       end
     end
@@ -238,10 +232,10 @@ describe PostPolicy do
       end
 
       it "is permitted to update their own issues" do
-        post = create(:post,
-                      user: pending_user,
-                      post_type: "issue",
-                      project: project)
+        post = build_stubbed(:post,
+                             user: pending_user,
+                             post_type: "issue",
+                             project: project)
         expect(subject).to permit(pending_user, post)
       end
     end
@@ -254,26 +248,26 @@ describe PostPolicy do
       end
 
       it "is permitted to update their own issue" do
-        post = create(:post,
-                      user: contributor_user,
-                      post_type: "issue",
-                      project: project)
+        post = build_stubbed(:post,
+                             user: contributor_user,
+                             post_type: "issue",
+                             project: project)
         expect(subject).to permit(contributor_user, post)
       end
 
       it "is permitted to update their own idea" do
-        post = create(:post,
-                      user: contributor_user,
-                      post_type: "idea",
-                      project: project)
+        post = build_stubbed(:post,
+                             user: contributor_user,
+                             post_type: "idea",
+                             project: project)
         expect(subject).to permit(contributor_user, post)
       end
 
       it "is permitted to update their own task" do
-        post = create(:post,
-                      user: contributor_user,
-                      post_type: "task",
-                      project: project)
+        post = build_stubbed(:post,
+                             user: contributor_user,
+                             post_type: "task",
+                             project: project)
         expect(subject).to permit(contributor_user, post)
       end
     end

--- a/spec/policies/project_category_policy_spec.rb
+++ b/spec/policies/project_category_policy_spec.rb
@@ -3,48 +3,43 @@ require "rails_helper"
 describe ProjectCategoryPolicy do
   subject { described_class }
 
+  let(:admin_user) { build_stubbed(:user) }
+  let(:contributor_user) { build_stubbed(:user) }
+  let(:organization) { create(:organization) }
+  let(:owner_user) { build_stubbed(:user) }
+  let(:pending_user) { build_stubbed(:user) }
+  let(:project) { build_stubbed(:project, organization: organization) }
+  let(:project_category) { build_stubbed(:project_category, project: project) }
+  let(:site_admin) { build_stubbed(:user, admin: true) }
+  let(:unaffiliated_organization) { create(:organization) }
+  let(:unaffiliated_project) { build_stubbed(:project, organization: unaffiliated_organization) }
+
+  let(:unaffiliated_project_category) do
+    build_stubbed(:project_category, project: unaffiliated_project)
+  end
+
+  let(:unaffiliated_user) { build_stubbed(:user) }
+
   before do
-    @organization = create(:organization)
-    @unaffiliated_organization = create(:organization)
-
-    @project = create(:project, organization: @organization)
-    @unaffiliated_project = create(:project, organization: @unaffiliated_organization)
-
-    @unaffiliated_user = create(:user)
-
-    # Pending organization member
-    @pending_user = create(:user)
     create(:organization_membership,
-           organization: @organization,
-           member: @pending_user,
+           organization: organization,
+           member: pending_user,
            role: "pending")
 
-    # Contributor organization member
-    @contributor_user = create(:user)
     create(:organization_membership,
-           organization: @organization,
-           member: @contributor_user,
+           organization: organization,
+           member: contributor_user,
            role: "contributor")
 
-    # Admin organization member
-    @admin_user = create(:user)
     create(:organization_membership,
-           organization: @organization,
-           member: @admin_user,
+           organization: organization,
+           member: admin_user,
            role: "admin")
 
-    # Owner organization member
-    @owner_user = create(:user)
     create(:organization_membership,
-           organization: @organization,
-           member: @owner_user,
+           organization: organization,
+           member: owner_user,
            role: "owner")
-
-    @project_category = create(:project_category, project: @project)
-
-    @unaffiliated_project_category = create(:project_category, project: @unaffiliated_project)
-
-    @site_admin = create(:user, admin: true)
   end
 
   permissions :create?, :destroy? do
@@ -56,61 +51,61 @@ describe ProjectCategoryPolicy do
 
     context "as an unaffiliated user" do
       it "is not permitted in other organizations" do
-        expect(subject).to_not permit(@unaffiliated_user, @unaffiliated_project_category)
+        expect(subject).to_not permit(unaffiliated_user, unaffiliated_project_category)
       end
 
       it "is not permitted in their organization" do
-        expect(subject).to_not permit(@unaffiliated_user, @project_category)
+        expect(subject).to_not permit(unaffiliated_user, project_category)
       end
     end
 
     context "as a pending user" do
       it "is not permitted in other organizations" do
-        expect(subject).to_not permit(@pending_user, @unaffiliated_project_category)
+        expect(subject).to_not permit(pending_user, unaffiliated_project_category)
       end
 
       it "is not permitted in their organization" do
-        expect(subject).to_not permit(@pending_user, @project_category)
+        expect(subject).to_not permit(pending_user, project_category)
       end
     end
 
     context "as a contributor user" do
       it "is not permitted in other organizations" do
-        expect(subject).to_not permit(@contributor_user, @unaffiliated_project_category)
+        expect(subject).to_not permit(contributor_user, unaffiliated_project_category)
       end
 
       it "is not permitted in their organization" do
-        expect(subject).to_not permit(@contributor_user, @project_category)
+        expect(subject).to_not permit(contributor_user, project_category)
       end
     end
 
     context "as an admin user" do
       it "is not permitted in other organizations" do
-        expect(subject).to_not permit(@admin_user, @unaffiliated_project_category)
+        expect(subject).to_not permit(admin_user, unaffiliated_project_category)
       end
 
       it "is permitted in their organization" do
-        expect(subject).to permit(@admin_user, @project_category)
+        expect(subject).to permit(admin_user, project_category)
       end
     end
 
     context "as an owner user" do
       it "is not permitted in other organizations" do
-        expect(subject).to_not permit(@owner_user, @unaffiliated_project_category)
+        expect(subject).to_not permit(owner_user, unaffiliated_project_category)
       end
 
       it "is permitted in their organization" do
-        expect(subject).to permit(@owner_user, @project_category)
+        expect(subject).to permit(owner_user, project_category)
       end
     end
 
     context "as a site admin" do
       it "is permitted in other organizations" do
-        expect(subject).to permit(@site_admin, @unaffiliated_project_category)
+        expect(subject).to permit(site_admin, unaffiliated_project_category)
       end
 
       it "is permitted in their organization" do
-        expect(subject).to permit(@site_admin, @project_category)
+        expect(subject).to permit(site_admin, project_category)
       end
     end
   end

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -1,104 +1,93 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe ProjectPolicy do
-
   subject { described_class }
 
+  let(:admin_user) { build_stubbed(:user) }
+  let(:contributor_user) { build_stubbed(:user) }
+  let(:organization) { create(:organization) }
+  let(:owner_user) { build_stubbed(:user) }
+  let(:pending_user) { build_stubbed(:user) }
+  let(:project) { build_stubbed(:project, organization: organization) }
+  let(:site_admin) { build_stubbed(:user, admin: true) }
+  let(:unaffiliated_organization) { create(:organization) }
+  let(:unaffiliated_project) { build_stubbed(:project, organization: unaffiliated_organization) }
+  let(:unaffiliated_user) { build_stubbed(:user) }
 
   before do
-    @organization = create(:organization)
-    @unaffiliated_organization = create(:organization)
-
-    @project = create(:project, organization: @organization)
-    @unaffiliated_project = create(:project, organization: @unaffiliated_organization)
-
-    @unaffiliated_user = create(:user)
-
-    # Pending organization member
-    @pending_user = create(:user)
     create(:organization_membership,
-           organization: @organization,
-           member: @pending_user,
+           organization: organization,
+           member: pending_user,
            role: "pending")
 
-    # Contributor organization member
-    @contributor_user = create(:user)
     create(:organization_membership,
-           organization: @organization,
-           member: @contributor_user,
+           organization: organization,
+           member: contributor_user,
            role: "contributor")
 
-    # Admin organization member
-    @admin_user = create(:user)
     create(:organization_membership,
-           organization: @organization,
-           member: @admin_user,
+           organization: organization,
+           member: admin_user,
            role: "admin")
 
-    # Owner organization member
-    @owner_user = create(:user)
     create(:organization_membership,
-           organization: @organization,
-           member: @owner_user,
+           organization: organization,
+           member: owner_user,
            role: "owner")
-
-    @site_admin = create(:user, admin: true)
   end
 
   permissions :index?, :show? do
-
     context "as a logged out user" do
       it "can view all projects" do
-        expect(subject).to permit(nil, @project)
-        expect(subject).to permit(nil, @unaffiliated_project)
+        expect(subject).to permit(nil, project)
+        expect(subject).to permit(nil, unaffiliated_project)
       end
     end
 
     context "as an unaffiliated user" do
       it "can view all projects" do
-        expect(subject).to permit(@unaffiliated_user, @project)
-        expect(subject).to permit(@unaffiliated_user, @unaffiliated_project)
+        expect(subject).to permit(unaffiliated_user, project)
+        expect(subject).to permit(unaffiliated_user, unaffiliated_project)
       end
     end
 
     context "as a pending user" do
       it "can view all projects" do
-        expect(subject).to permit(@pending_user, @project)
-        expect(subject).to permit(@pending_user, @unaffiliated_project)
+        expect(subject).to permit(pending_user, project)
+        expect(subject).to permit(pending_user, unaffiliated_project)
       end
     end
 
     context "as a contributor user" do
       it "can view all projects" do
-        expect(subject).to permit(@contributor_user, @project)
-        expect(subject).to permit(@contributor_user, @unaffiliated_project)
+        expect(subject).to permit(contributor_user, project)
+        expect(subject).to permit(contributor_user, unaffiliated_project)
       end
     end
 
     context "as an admin user" do
       it "can view all projects" do
-        expect(subject).to permit(@admin_user, @project)
-        expect(subject).to permit(@admin_user, @unaffiliated_project)
+        expect(subject).to permit(admin_user, project)
+        expect(subject).to permit(admin_user, unaffiliated_project)
       end
     end
 
     context "as an owner user" do
       it "can view all projects" do
-        expect(subject).to permit(@owner_user, @project)
-        expect(subject).to permit(@owner_user, @unaffiliated_project)
+        expect(subject).to permit(owner_user, project)
+        expect(subject).to permit(owner_user, unaffiliated_project)
       end
     end
 
     context "as a site admin" do
       it "can view all projects" do
-        expect(subject).to permit(@site_admin, @project)
-        expect(subject).to permit(@site_admin, @unaffiliated_project)
+        expect(subject).to permit(site_admin, project)
+        expect(subject).to permit(site_admin, unaffiliated_project)
       end
     end
   end
 
   permissions :create?, :update? do
-
     context "as a logged out user" do
       it "is not permitted to create/update projects" do
         expect(subject).to_not permit(nil, create(:project))
@@ -107,61 +96,61 @@ describe ProjectPolicy do
 
     context "as an unaffiliated user" do
       it "is not permitted to create/update projects in other organizations" do
-        expect(subject).to_not permit(@unaffiliated_user, @unaffiliated_project)
+        expect(subject).to_not permit(unaffiliated_user, unaffiliated_project)
       end
 
       it "is not permitted to create/update projects in their organization" do
-        expect(subject).to_not permit(@unaffiliated_user, @project)
+        expect(subject).to_not permit(unaffiliated_user, project)
       end
     end
 
     context "as a pending user" do
       it "is not permitted to create/update projects in other organizations" do
-        expect(subject).to_not permit(@pending_user, @unaffiliated_project)
+        expect(subject).to_not permit(pending_user, unaffiliated_project)
       end
 
       it "is not permitted to create/update projects in their organization" do
-        expect(subject).to_not permit(@pending_user, @project)
+        expect(subject).to_not permit(pending_user, project)
       end
     end
 
     context "as a contributor user" do
       it "is not permitted to create/update projects in other organizations" do
-        expect(subject).to_not permit(@contributor_user, @unaffiliated_project)
+        expect(subject).to_not permit(contributor_user, unaffiliated_project)
       end
 
       it "is not permitted to create/update projects in their organization" do
-        expect(subject).to_not permit(@contributor_user, @project)
+        expect(subject).to_not permit(contributor_user, project)
       end
     end
 
     context "as an admin user" do
       it "is not permitted to create/update projects in other organizations" do
-        expect(subject).to_not permit(@admin_user, @unaffiliated_project)
+        expect(subject).to_not permit(admin_user, unaffiliated_project)
       end
 
       it "is permitted to create/update projects in their organization" do
-        expect(subject).to permit(@admin_user, @project)
+        expect(subject).to permit(admin_user, project)
       end
     end
 
     context "as an owner user" do
       it "is not permitted to create/update projects in other organizations" do
-        expect(subject).to_not permit(@owner_user, @unaffiliated_project)
+        expect(subject).to_not permit(owner_user, unaffiliated_project)
       end
 
       it "is permitted to create/update projects in their organization" do
-        expect(subject).to permit(@owner_user, @project)
+        expect(subject).to permit(owner_user, project)
       end
     end
 
     context "as a site admin" do
       it "is permitted to create projects in other organizations" do
-        expect(subject).to permit(@site_admin, @unaffiliated_project)
+        expect(subject).to permit(site_admin, unaffiliated_project)
       end
 
       it "is permitted to create projects in their organization" do
-        expect(subject).to permit(@site_admin, @project)
+        expect(subject).to permit(site_admin, project)
       end
     end
   end

--- a/spec/policies/project_role_policy_spec.rb
+++ b/spec/policies/project_role_policy_spec.rb
@@ -3,48 +3,39 @@ require "rails_helper"
 describe ProjectRolePolicy do
   subject { described_class }
 
+  let(:admin_user) { build_stubbed(:user) }
+  let(:contributor_user) { build_stubbed(:user) }
+  let(:organization) { create(:organization) }
+  let(:owner_user) { build_stubbed(:user) }
+  let(:pending_user) { build_stubbed(:user) }
+  let(:project) { build_stubbed(:project, organization: organization) }
+  let(:project_role) { build_stubbed(:project_role, project: project) }
+  let(:site_admin) { build_stubbed(:user, admin: true) }
+  let(:unaffiliated_organization) { create(:organization) }
+  let(:unaffiliated_project) { build_stubbed(:project, organization: unaffiliated_organization) }
+  let(:unaffiliated_project_role) { build_stubbed(:project_role, project: unaffiliated_project) }
+  let(:unaffiliated_user) { build_stubbed(:user) }
+
   before do
-    @organization = create(:organization)
-    @unaffiliated_organization = create(:organization)
-
-    @project = create(:project, organization: @organization)
-    @unaffiliated_project = create(:project, organization: @unaffiliated_organization)
-
-    @unaffiliated_user = create(:user)
-
-    # Pending organization member
-    @pending_user = create(:user)
     create(:organization_membership,
-           organization: @organization,
-           member: @pending_user,
+           organization: organization,
+           member: pending_user,
            role: "pending")
 
-    # Contributor organization member
-    @contributor_user = create(:user)
     create(:organization_membership,
-           organization: @organization,
-           member: @contributor_user,
+           organization: organization,
+           member: contributor_user,
            role: "contributor")
 
-    # Admin organization member
-    @admin_user = create(:user)
     create(:organization_membership,
-           organization: @organization,
-           member: @admin_user,
+           organization: organization,
+           member: admin_user,
            role: "admin")
 
-    # Owner organization member
-    @owner_user = create(:user)
     create(:organization_membership,
-           organization: @organization,
-           member: @owner_user,
+           organization: organization,
+           member: owner_user,
            role: "owner")
-
-    @project_role = create(:project_role, project: @project)
-
-    @unaffiliated_project_role = create(:project_role, project: @unaffiliated_project)
-
-    @site_admin = create(:user, admin: true)
   end
 
   permissions :create?, :destroy? do
@@ -56,61 +47,61 @@ describe ProjectRolePolicy do
 
     context "as an unaffiliated user" do
       it "is not permitted in other organizations" do
-        expect(subject).to_not permit(@unaffiliated_user, @unaffiliated_project_role)
+        expect(subject).to_not permit(unaffiliated_user, unaffiliated_project_role)
       end
 
       it "is not permitted in their organization" do
-        expect(subject).to_not permit(@unaffiliated_user, @project_role)
+        expect(subject).to_not permit(unaffiliated_user, project_role)
       end
     end
 
     context "as a pending user" do
       it "is not permitted in other organizations" do
-        expect(subject).to_not permit(@pending_user, @unaffiliated_project_role)
+        expect(subject).to_not permit(pending_user, unaffiliated_project_role)
       end
 
       it "is not permitted in their organization" do
-        expect(subject).to_not permit(@pending_user, @project_role)
+        expect(subject).to_not permit(pending_user, project_role)
       end
     end
 
     context "as a contributor user" do
       it "is not permitted in other organizations" do
-        expect(subject).to_not permit(@contributor_user, @unaffiliated_project_role)
+        expect(subject).to_not permit(contributor_user, unaffiliated_project_role)
       end
 
       it "is not permitted in their organization" do
-        expect(subject).to_not permit(@contributor_user, @project_role)
+        expect(subject).to_not permit(contributor_user, project_role)
       end
     end
 
     context "as an admin user" do
       it "is not permitted in other organizations" do
-        expect(subject).to_not permit(@admin_user, @unaffiliated_project_role)
+        expect(subject).to_not permit(admin_user, unaffiliated_project_role)
       end
 
       it "is permitted in their organization" do
-        expect(subject).to permit(@admin_user, @project_role)
+        expect(subject).to permit(admin_user, project_role)
       end
     end
 
     context "as an owner user" do
       it "is not permitted in other organizations" do
-        expect(subject).to_not permit(@owner_user, @unaffiliated_project_role)
+        expect(subject).to_not permit(owner_user, unaffiliated_project_role)
       end
 
       it "is permitted in their organization" do
-        expect(subject).to permit(@owner_user, @project_role)
+        expect(subject).to permit(owner_user, project_role)
       end
     end
 
     context "as a site admin" do
       it "is permitted in other organizations" do
-        expect(subject).to permit(@site_admin, @unaffiliated_project_role)
+        expect(subject).to permit(site_admin, unaffiliated_project_role)
       end
 
       it "is permitted in their organization" do
-        expect(subject).to permit(@site_admin, @project_role)
+        expect(subject).to permit(site_admin, project_role)
       end
     end
   end

--- a/spec/policies/project_skill_policy_spec.rb
+++ b/spec/policies/project_skill_policy_spec.rb
@@ -3,48 +3,39 @@ require "rails_helper"
 describe ProjectSkillPolicy do
   subject { described_class }
 
+  let(:admin_user) { build_stubbed(:user) }
+  let(:contributor_user) { build_stubbed(:user) }
+  let(:organization) { create(:organization) }
+  let(:owner_user) { build_stubbed(:user) }
+  let(:pending_user) { build_stubbed(:user) }
+  let(:project) { build_stubbed(:project, organization: organization) }
+  let(:project_skill) { build_stubbed(:project_skill, project: project) }
+  let(:site_admin) { build_stubbed(:user, admin: true) }
+  let(:unaffiliated_organization) { create(:organization) }
+  let(:unaffiliated_project) { build_stubbed(:project, organization: unaffiliated_organization) }
+  let(:unaffiliated_project_skill) { build_stubbed(:project_skill, project: unaffiliated_project) }
+  let(:unaffiliated_user) { build_stubbed(:user) }
+
   before do
-    @organization = create(:organization)
-    @unaffiliated_organization = create(:organization)
-
-    @project = create(:project, organization: @organization)
-    @unaffiliated_project = create(:project, organization: @unaffiliated_organization)
-
-    @unaffiliated_user = create(:user)
-
-    # Pending organization member
-    @pending_user = create(:user)
     create(:organization_membership,
-           organization: @organization,
-           member: @pending_user,
+           organization: organization,
+           member: pending_user,
            role: "pending")
 
-    # Contributor organization member
-    @contributor_user = create(:user)
     create(:organization_membership,
-           organization: @organization,
-           member: @contributor_user,
+           organization: organization,
+           member: contributor_user,
            role: "contributor")
 
-    # Admin organization member
-    @admin_user = create(:user)
     create(:organization_membership,
-           organization: @organization,
-           member: @admin_user,
+           organization: organization,
+           member: admin_user,
            role: "admin")
 
-    # Owner organization member
-    @owner_user = create(:user)
     create(:organization_membership,
-           organization: @organization,
-           member: @owner_user,
+           organization: organization,
+           member: owner_user,
            role: "owner")
-
-    @project_skill = create(:project_skill, project: @project)
-
-    @unaffiliated_project_skill = create(:project_skill, project: @unaffiliated_project)
-
-    @site_admin = create(:user, admin: true)
   end
 
   permissions :create?, :destroy? do
@@ -56,61 +47,61 @@ describe ProjectSkillPolicy do
 
     context "as an unaffiliated user" do
       it "is not permitted in other organizations" do
-        expect(subject).to_not permit(@unaffiliated_user, @unaffiliated_project_skill)
+        expect(subject).to_not permit(unaffiliated_user, unaffiliated_project_skill)
       end
 
       it "is not permitted in their organization" do
-        expect(subject).to_not permit(@unaffiliated_user, @project_skill)
+        expect(subject).to_not permit(unaffiliated_user, project_skill)
       end
     end
 
     context "as a pending user" do
       it "is not permitted in other organizations" do
-        expect(subject).to_not permit(@pending_user, @unaffiliated_project_skill)
+        expect(subject).to_not permit(pending_user, unaffiliated_project_skill)
       end
 
       it "is not permitted in their organization" do
-        expect(subject).to_not permit(@pending_user, @project_skill)
+        expect(subject).to_not permit(pending_user, project_skill)
       end
     end
 
     context "as a contributor user" do
       it "is not permitted in other organizations" do
-        expect(subject).to_not permit(@contributor_user, @unaffiliated_project_skill)
+        expect(subject).to_not permit(contributor_user, unaffiliated_project_skill)
       end
 
       it "is not permitted in their organization" do
-        expect(subject).to_not permit(@contributor_user, @project_skill)
+        expect(subject).to_not permit(contributor_user, project_skill)
       end
     end
 
     context "as an admin user" do
       it "is not permitted in other organizations" do
-        expect(subject).to_not permit(@admin_user, @unaffiliated_project_skill)
+        expect(subject).to_not permit(admin_user, unaffiliated_project_skill)
       end
 
       it "is permitted in their organization" do
-        expect(subject).to permit(@admin_user, @project_skill)
+        expect(subject).to permit(admin_user, project_skill)
       end
     end
 
     context "as an owner user" do
       it "is not permitted in other organizations" do
-        expect(subject).to_not permit(@owner_user, @unaffiliated_project_skill)
+        expect(subject).to_not permit(owner_user, unaffiliated_project_skill)
       end
 
       it "is permitted in their organization" do
-        expect(subject).to permit(@owner_user, @project_skill)
+        expect(subject).to permit(owner_user, project_skill)
       end
     end
 
     context "as a site admin" do
       it "is permitted in other organizations" do
-        expect(subject).to permit(@site_admin, @unaffiliated_project_skill)
+        expect(subject).to permit(site_admin, unaffiliated_project_skill)
       end
 
       it "is permitted in their organization" do
-        expect(subject).to permit(@site_admin, @project_skill)
+        expect(subject).to permit(site_admin, project_skill)
       end
     end
   end

--- a/spec/policies/role_policy_spec.rb
+++ b/spec/policies/role_policy_spec.rb
@@ -3,28 +3,26 @@ require "rails_helper"
 describe RolePolicy do
   subject { described_class }
 
-  before do
-    @role = create(:role)
-    @regular_user = create(:user)
-    @site_admin = create(:user, admin: true)
-  end
+  let(:regular_user) { build_stubbed(:user) }
+  let(:role) { build_stubbed(:role) }
+  let(:site_admin) { build_stubbed(:user, admin: true) }
 
   permissions :index? do
     context "as a logged out user" do
       it "can view all roles" do
-        expect(subject).to permit(nil, @role)
+        expect(subject).to permit(nil, role)
       end
     end
 
     context "as a regular user" do
       it "can view all roles" do
-        expect(subject).to permit(@regular_user, @role)
+        expect(subject).to permit(regular_user, role)
       end
     end
 
     context "as a site admin" do
       it "can view all roles" do
-        expect(subject).to permit(@site_admin, @role)
+        expect(subject).to permit(site_admin, role)
       end
     end
   end
@@ -32,19 +30,19 @@ describe RolePolicy do
   permissions :create?, :update? do
     context "as a logged out user" do
       it "is not permitted to create/update roles" do
-        expect(subject).to_not permit(nil, @role)
+        expect(subject).to_not permit(nil, role)
       end
     end
 
     context "as a regular user" do
       it "is not permitted to create/update roles" do
-        expect(subject).to_not permit(@regular_user, @role)
+        expect(subject).to_not permit(regular_user, role)
       end
     end
 
     context "as a site admin" do
       it "is permitted to create/update roles" do
-        expect(subject).to permit(@site_admin, @role)
+        expect(subject).to permit(site_admin, role)
       end
     end
   end

--- a/spec/policies/role_skill_policy_spec.rb
+++ b/spec/policies/role_skill_policy_spec.rb
@@ -3,28 +3,26 @@ require "rails_helper"
 describe RoleSkillPolicy do
   subject { described_class }
 
-  before do
-    @role_skill = create(:role_skill)
-    @regular_user = create(:user)
-    @site_admin = create(:user, admin: true)
-  end
+  let(:regular_user) { build_stubbed(:user) }
+  let(:role_skill) { build_stubbed(:role_skill) }
+  let(:site_admin) { build_stubbed(:user, admin: true) }
 
   permissions :index?, :show? do
     context "as a logged out user" do
       it "can view all" do
-        expect(subject).to permit(nil, @role)
+        expect(subject).to permit(nil, role_skill)
       end
     end
 
     context "as a regular user" do
       it "can view all" do
-        expect(subject).to permit(@regular_user, @role)
+        expect(subject).to permit(regular_user, role_skill)
       end
     end
 
     context "as a site admin" do
       it "can view all" do
-        expect(subject).to permit(@site_admin, @role)
+        expect(subject).to permit(site_admin, role_skill)
       end
     end
   end
@@ -32,19 +30,19 @@ describe RoleSkillPolicy do
   permissions :create?, :destroy? do
     context "as a logged out user" do
       it "is not permitted" do
-        expect(subject).to_not permit(nil, @role)
+        expect(subject).to_not permit(nil, role_skill)
       end
     end
 
     context "as a regular user" do
       it "is not permitted" do
-        expect(subject).to_not permit(@regular_user, @role)
+        expect(subject).to_not permit(regular_user, role_skill)
       end
     end
 
     context "as a site admin" do
       it "is permitted" do
-        expect(subject).to permit(@site_admin, @role)
+        expect(subject).to permit(site_admin, role_skill)
       end
     end
   end

--- a/spec/policies/skill_policy_spec.rb
+++ b/spec/policies/skill_policy_spec.rb
@@ -3,28 +3,26 @@ require "rails_helper"
 describe SkillPolicy do
   subject { described_class }
 
-  before do
-    @skill = create(:skill)
-    @regular_user = create(:user)
-    @site_admin = create(:user, admin: true)
-  end
+  let(:regular_user) { build_stubbed(:user) }
+  let(:site_admin) { build_stubbed(:user, admin: true) }
+  let(:skill) { build_stubbed(:skill) }
 
   permissions :index?, :show?, :search? do
     context "as a logged out user" do
       it "can view all skills" do
-        expect(subject).to permit(nil, @skill)
+        expect(subject).to permit(nil, skill)
       end
     end
 
     context "as a regular user" do
       it "can view all skills" do
-        expect(subject).to permit(@regular_user, @skill)
+        expect(subject).to permit(regular_user, skill)
       end
     end
 
     context "as a site admin" do
       it "can view all skills" do
-        expect(subject).to permit(@site_admin, @skill)
+        expect(subject).to permit(site_admin, skill)
       end
     end
   end
@@ -32,19 +30,19 @@ describe SkillPolicy do
   permissions :create?, :update? do
     context "as a logged out user" do
       it "is not permitted to create/update skills" do
-        expect(subject).to_not permit(nil, @skill)
+        expect(subject).to_not permit(nil, skill)
       end
     end
 
     context "as a regular user" do
       it "is not permitted to create/update skills" do
-        expect(subject).to_not permit(@regular_user, @skill)
+        expect(subject).to_not permit(regular_user, skill)
       end
     end
 
     context "as a site admin" do
       it "is permitted to create/update skills" do
-        expect(subject).to permit(@site_admin, @skill)
+        expect(subject).to permit(site_admin, skill)
       end
     end
   end

--- a/spec/policies/slugged_route_policy_spec.rb
+++ b/spec/policies/slugged_route_policy_spec.rb
@@ -3,14 +3,11 @@ require "rails_helper"
 describe SluggedRoutePolicy do
   subject { described_class }
 
-  before do
-    organization = create(:organization)
-    @slugged_route = organization.slugged_route
-  end
+  let(:organization) { build_stubbed(:organization) }
 
   permissions :show? do
     it "is permited for anyone" do
-      expect(subject).to permit(nil, @slugged_route)
+      expect(subject).to permit(nil, organization.slugged_route)
     end
   end
 end

--- a/spec/policies/user_category_policy_spec.rb
+++ b/spec/policies/user_category_policy_spec.rb
@@ -3,28 +3,26 @@ require "rails_helper"
 describe UserCategoryPolicy do
   subject { described_class }
 
-  before do
-    @user = create(:user)
-    @another_user = create(:user)
-    @user_category = create(:user_category, user: @user)
-  end
+  let(:another_user) { build_stubbed(:user) }
+  let(:user) { build_stubbed(:user) }
+  let(:user_category) { build_stubbed(:user_category, user: user) }
 
   permissions :index?, :show? do
     context "as a logged out user" do
       it "can view all" do
-        expect(subject).to permit(nil, @user_category)
+        expect(subject).to permit(nil, user_category)
       end
     end
 
     context "as the user" do
       it "can view all" do
-        expect(subject).to permit(@user, @user_category)
+        expect(subject).to permit(user, user_category)
       end
     end
 
     context "as another user" do
       it "can view all" do
-        expect(subject).to permit(@another_user, @user_category)
+        expect(subject).to permit(another_user, user_category)
       end
     end
   end
@@ -32,19 +30,19 @@ describe UserCategoryPolicy do
   permissions :create?, :destroy? do
     context "as a logged out user" do
       it "is not permitted" do
-        expect(subject).to_not permit(nil, @user_category)
+        expect(subject).to_not permit(nil, user_category)
       end
     end
 
     context "as a regular user" do
       it "is permitted" do
-        expect(subject).to permit(@user, @user_category)
+        expect(subject).to permit(user, user_category)
       end
     end
 
     context "as a site admin" do
       it "is not permitted" do
-        expect(subject).to_not permit(@another_user, @user_category)
+        expect(subject).to_not permit(another_user, user_category)
       end
     end
   end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 describe UserPolicy do
   subject { described_class }
+
   let(:admin_user) { build_stubbed(:user, admin: true) }
   let(:user) { build_stubbed(:user) }
 

--- a/spec/policies/user_role_policy_spec.rb
+++ b/spec/policies/user_role_policy_spec.rb
@@ -3,28 +3,26 @@ require "rails_helper"
 describe UserRolePolicy do
   subject { described_class }
 
-  before do
-    @user = create(:user)
-    @another_user = create(:user)
-    @user_role = create(:user_role, user: @user, role: create(:role))
-  end
+  let(:another_user) { build_stubbed(:user) }
+  let(:user) { build_stubbed(:user) }
+  let(:user_role) { build_stubbed(:user_role, user: user, role: build_stubbed(:role)) }
 
   permissions :index?, :show? do
     context "as a logged out user" do
       it "can view all" do
-        expect(subject).to permit(nil, @user_role)
+        expect(subject).to permit(nil, user_role)
       end
     end
 
     context "as the user" do
       it "can view all" do
-        expect(subject).to permit(@user, @user_role)
+        expect(subject).to permit(user, user_role)
       end
     end
 
     context "as another user" do
       it "can view all" do
-        expect(subject).to permit(@another_user, @user_role)
+        expect(subject).to permit(another_user, user_role)
       end
     end
   end
@@ -32,19 +30,19 @@ describe UserRolePolicy do
   permissions :create?, :destroy? do
     context "as a logged out user" do
       it "is not permitted" do
-        expect(subject).to_not permit(nil, @user_role)
+        expect(subject).to_not permit(nil, user_role)
       end
     end
 
     context "as a regular user" do
       it "is permitted" do
-        expect(subject).to permit(@user, @user_role)
+        expect(subject).to permit(user, user_role)
       end
     end
 
     context "as a site admin" do
       it "is not permitted" do
-        expect(subject).to_not permit(@another_user, @user_role)
+        expect(subject).to_not permit(another_user, user_role)
       end
     end
   end

--- a/spec/policies/user_skill_policy_spec.rb
+++ b/spec/policies/user_skill_policy_spec.rb
@@ -3,28 +3,26 @@ require "rails_helper"
 describe UserSkillPolicy do
   subject { described_class }
 
-  before do
-    @user = create(:user)
-    @another_user = create(:user)
-    @user_skill = create(:user_skill, user: @user)
-  end
+  let(:another_user) { build_stubbed(:user) }
+  let(:user) { build_stubbed(:user) }
+  let(:user_skill) { build_stubbed(:user_skill, user: user) }
 
   permissions :index?, :show? do
     context "as a logged out user" do
       it "can view all" do
-        expect(subject).to permit(nil, @user_skill)
+        expect(subject).to permit(nil, user_skill)
       end
     end
 
     context "as the user" do
       it "can view all" do
-        expect(subject).to permit(@user, @user_skill)
+        expect(subject).to permit(user, user_skill)
       end
     end
 
     context "as another user" do
       it "can view all" do
-        expect(subject).to permit(@another_user, @user_skill)
+        expect(subject).to permit(another_user, user_skill)
       end
     end
   end
@@ -32,19 +30,19 @@ describe UserSkillPolicy do
   permissions :create?, :destroy? do
     context "as a logged out user" do
       it "is not permitted" do
-        expect(subject).to_not permit(nil, @user_skill)
+        expect(subject).to_not permit(nil, user_skill)
       end
     end
 
     context "as a regular user" do
       it "is permitted" do
-        expect(subject).to permit(@user, @user_skill)
+        expect(subject).to permit(user, user_skill)
       end
     end
 
     context "as a site admin" do
       it "is not permitted" do
-        expect(subject).to_not permit(@another_user, @user_skill)
+        expect(subject).to_not permit(another_user, user_skill)
       end
     end
   end


### PR DESCRIPTION
Using `build_stubbed` significantly speeds up specs by reducing trips to the database. See the following:

https://robots.thoughtbot.com/use-factory-girls-build-stubbed-for-a-faster-test

Prior to this update, policy specs often ran in total around 25–28s. After the update, run times seem to be between 6–9s. :racehorse::dash: 

We can probably apply the same to other specs, quite easily for models.
