### PR TITLE
Prepend log lines with uuid

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,7 +49,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  # config.log_tags = [ :subdomain, :uuid ]
+  config.log_tags = [:uuid]
 
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)


### PR DESCRIPTION
By prepending the uuid to each log line, we can correlate the router and dyno logs with our application logs for that same request. This will help us locate the source of platform errors. 

See the Heroku Devcenter article on [HTTP Request IDs](https://devcenter.heroku.com/articles/http-request-id#usage-with-rails) for more info.
