### PR TITLE
Change 401 to 403 for Pundit authorization errors

### DIFF
--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -1,13 +1,21 @@
 class ErrorSerializer
   def self.serialize(error)
-    error_hash = serialize_doorkeeper_oauth_invalid_token_response(error) if error.class == Doorkeeper::OAuth::InvalidTokenResponse
-    error_hash = serialize_doorkeeper_oauth_error_response(error) if error.class == Doorkeeper::OAuth::ErrorResponse
-    error_hash = serialize_validation_errors(error) if error.class == ActiveModel::Errors
-    error_hash = serialize_pundit_not_authorized_error(error) if error.class == Pundit::NotAuthorizedError
-    error_hash = serialize_parameter_missing(error) if error.class == ActionController::ParameterMissing
-    error_hash = serialize_action_controller_routing_error(error) if error.class == ActionController::RoutingError
-    error_hash = serialize_facebook_authentication_error(error) if error.class == Koala::Facebook::AuthenticationError
-    error_hash = serialize_record_not_found_error(error) if error.class == ActiveRecord::RecordNotFound
+    error_hash = serialize_doorkeeper_oauth_invalid_token_response(error) if
+      error.class == Doorkeeper::OAuth::InvalidTokenResponse
+    error_hash = serialize_doorkeeper_oauth_error_response(error) if
+      error.class == Doorkeeper::OAuth::ErrorResponse
+    error_hash = serialize_validation_errors(error) if
+      error.class == ActiveModel::Errors
+    error_hash = serialize_pundit_not_authorized_error(error) if
+      error.class == Pundit::NotAuthorizedError
+    error_hash = serialize_parameter_missing(error) if
+      error.class == ActionController::ParameterMissing
+    error_hash = serialize_action_controller_routing_error(error) if
+      error.class == ActionController::RoutingError
+    error_hash = serialize_facebook_authentication_error(error) if
+      error.class == Koala::Facebook::AuthenticationError
+    error_hash = serialize_record_not_found_error(error) if
+      error.class == ActiveRecord::RecordNotFound
 
     { errors: Array.wrap(error_hash) }
   end
@@ -35,10 +43,10 @@ class ErrorSerializer
     def self.serialize_pundit_not_authorized_error(error)
       subject_name = error.record.class.to_s.pluralize.underscore.humanize.downcase
       return {
-        id: "ACCESS_DENIED",
-        title: "Access denied",
+        id: "FORBIDDEN",
+        title: "Forbidden",
         detail: "You are not authorized to perform this action on #{subject_name}.",
-        status: 401
+        status: 403
       }
     end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -272,6 +272,7 @@ ActiveRecord::Schema.define(version: 20160626090623) do
     t.text     "base64_icon_data"
     t.string   "slug",                                  null: false
     t.integer  "organization_id",                       null: false
+    t.string   "aasm_state"
     t.text     "long_description_body"
     t.text     "long_description_markdown"
     t.integer  "open_posts_count",          default: 0, null: false

--- a/spec/requests/api/categories_spec.rb
+++ b/spec/requests/api/categories_spec.rb
@@ -70,10 +70,10 @@ describe "Categories API" do
       end
 
       context "as a regular user" do
-        it "responds with a 401 access denied" do
+        it "responds with a 403 forbidden" do
           make_request(params)
-          expect(last_response.status).to eq 401
-          expect(json).to be_a_valid_json_api_error.with_id "ACCESS_DENIED"
+          expect(last_response.status).to eq 403
+          expect(json).to be_a_valid_json_api_error.with_id "FORBIDDEN"
         end
       end
 

--- a/spec/requests/api/comment_images_spec.rb
+++ b/spec/requests/api/comment_images_spec.rb
@@ -110,9 +110,9 @@ describe "Comment Images API" do
           authenticated_post "/comment_images", params, @token
         end
 
-        it "responds with a 401 ACCESS_DENIED" do
-          expect(last_response.status).to eq 401
-          expect(json).to be_a_valid_json_api_error.with_id "ACCESS_DENIED"
+        it "responds with a 403 FORBIDDEN" do
+          expect(last_response.status).to eq 403
+          expect(json).to be_a_valid_json_api_error.with_id "FORBIDDEN"
         end
       end
     end

--- a/spec/requests/api/github_repositories_spec.rb
+++ b/spec/requests/api/github_repositories_spec.rb
@@ -22,14 +22,14 @@ describe "GithubRepositories API" do
       end
 
       context "when user has insufficient access rights" do
-        it "responds with a 401" do
+        it "responds with a 403" do
           authenticated_post "/github_repositories", { data: {
             attributes: { url: "https://github.com/code-corps/code-corps-api" },
             relationships: { project: { data: { type: "projects", id: @project.id } } }
           } }, token
 
-          expect(last_response.status).to eq 401
-          expect(json).to be_a_valid_json_api_error.with_id "ACCESS_DENIED"
+          expect(last_response.status).to eq 403
+          expect(json).to be_a_valid_json_api_error.with_id "FORBIDDEN"
         end
       end
 

--- a/spec/requests/api/import_skill_failures_spec.rb
+++ b/spec/requests/api/import_skill_failures_spec.rb
@@ -18,8 +18,8 @@ describe "ImportSkillFailures API" do
 
         it "responds with a proper message" do
           authenticated_get "/import_skill_failures", nil, token
-          expect(last_response.status).to eq 401
-          expect(json).to be_a_valid_json_api_error.with_id "ACCESS_DENIED"
+          expect(last_response.status).to eq 403
+          expect(json).to be_a_valid_json_api_error.with_id "FORBIDDEN"
         end
       end
 

--- a/spec/requests/api/imports_spec.rb
+++ b/spec/requests/api/imports_spec.rb
@@ -64,9 +64,9 @@ describe "Imports API" do
           authenticated_post "/imports", params, token
         end
 
-        it "responds with a 401 ACCESS_DENIED" do
-          expect(last_response.status).to eq 401
-          expect(json).to be_a_valid_json_api_error.with_id "ACCESS_DENIED"
+        it "responds with a 403 FORBIDDEN" do
+          expect(last_response.status).to eq 403
+          expect(json).to be_a_valid_json_api_error.with_id "FORBIDDEN"
         end
       end
     end

--- a/spec/requests/api/organization_memberships_spec.rb
+++ b/spec/requests/api/organization_memberships_spec.rb
@@ -173,7 +173,7 @@ describe "OrganizationMemberships API" do
       let(:token) { authenticate email: applicant.email, password: "password" }
 
       context "when unauthorized" do
-        it "respond with 401 ACCESS_DENIED" do
+        it "respond with 403 FORBIDDEN" do
           authenticated_post "/organization_memberships", {
             data: {
               type: "organization_memberships",
@@ -185,8 +185,8 @@ describe "OrganizationMemberships API" do
             }
           }, token
 
-          expect(last_response.status).to eq 401
-          expect(json).to be_a_valid_json_api_error.with_id "ACCESS_DENIED"
+          expect(last_response.status).to eq 403
+          expect(json).to be_a_valid_json_api_error.with_id "FORBIDDEN"
         end
       end
 
@@ -232,7 +232,7 @@ describe "OrganizationMemberships API" do
 
     context "when authenticated" do
       context "when unauthorized" do
-        it "respond with 401 ACCESS_DENIED" do
+        it "respond with 403 FORBIDDEN" do
           token = authenticate(email: applicant.email, password: "password")
 
           authenticated_patch "/organization_memberships/#{membership.id}", {
@@ -242,8 +242,8 @@ describe "OrganizationMemberships API" do
             }
           }, token
 
-          expect(last_response.status).to eq 401
-          expect(json).to be_a_valid_json_api_error.with_id "ACCESS_DENIED"
+          expect(last_response.status).to eq 403
+          expect(json).to be_a_valid_json_api_error.with_id "FORBIDDEN"
         end
       end
 
@@ -295,13 +295,13 @@ describe "OrganizationMemberships API" do
       end
 
       context "when unauthorized" do
-        it "responds with 401 ACCESS_DENIED" do
+        it "responds with 403 FORBIDDEN" do
           token = authenticate(email: user.email, password: "password")
 
           authenticated_delete "/organization_memberships/#{membership.id}", {}, token
 
-          expect(last_response.status).to eq 401
-          expect(json).to be_a_valid_json_api_error.with_id "ACCESS_DENIED"
+          expect(last_response.status).to eq 403
+          expect(json).to be_a_valid_json_api_error.with_id "FORBIDDEN"
         end
       end
 

--- a/spec/requests/api/organizations_spec.rb
+++ b/spec/requests/api/organizations_spec.rb
@@ -54,11 +54,11 @@ describe "Organizations API" do
         let(:user) { create(:user, password: "password") }
         let(:token) { authenticate(email: user.email, password: "password") }
 
-        it "responds with a 401 ACCESS_DENIED" do
+        it "responds with a 403 FORBIDDEN" do
           authenticated_post "/organizations", {}, token
 
-          expect(last_response.status).to eq 401
-          expect(json).to be_a_valid_json_api_error.with_id "ACCESS_DENIED"
+          expect(last_response.status).to eq 403
+          expect(json).to be_a_valid_json_api_error.with_id "FORBIDDEN"
         end
       end
 

--- a/spec/requests/api/post_images_spec.rb
+++ b/spec/requests/api/post_images_spec.rb
@@ -99,9 +99,9 @@ describe "Post Images API" do
           authenticated_post "/post_images", params, @token
         end
 
-        it "responds with a 401 ACCESS_DENIED" do
-          expect(last_response.status).to eq 401
-          expect(json).to be_a_valid_json_api_error.with_id "ACCESS_DENIED"
+        it "responds with a 403 FORBIDDEN" do
+          expect(last_response.status).to eq 403
+          expect(json).to be_a_valid_json_api_error.with_id "FORBIDDEN"
         end
       end
     end

--- a/spec/requests/api/post_likes_spec.rb
+++ b/spec/requests/api/post_likes_spec.rb
@@ -101,7 +101,6 @@ describe "PostLikes API" do
     end
 
     context "when authenticated" do
-
       let(:token) { authenticate(email: "josh@coderly.com", password: "password") }
 
       before do
@@ -113,8 +112,8 @@ describe "PostLikes API" do
 
         authenticated_delete "/post_likes/1", {}, token
 
-        expect(last_response.status).to eq 401
-        expect(json).to be_a_valid_json_api_error.with_id "ACCESS_DENIED"
+        expect(last_response.status).to eq 403
+        expect(json).to be_a_valid_json_api_error.with_id "FORBIDDEN"
         expect(PostLike.count).to eq 1
       end
 

--- a/spec/requests/api/project_categories_spec.rb
+++ b/spec/requests/api/project_categories_spec.rb
@@ -158,8 +158,8 @@ describe "ProjectCategories API" do
 
           authenticated_delete "/project_categories/1", {}, token
 
-          expect(last_response.status).to eq 401
-          expect(json).to be_a_valid_json_api_error.with_id "ACCESS_DENIED"
+          expect(last_response.status).to eq 403
+          expect(json).to be_a_valid_json_api_error.with_id "FORBIDDEN"
           expect(ProjectCategory.count).to eq 1
         end
       end

--- a/spec/requests/api/project_roles_spec.rb
+++ b/spec/requests/api/project_roles_spec.rb
@@ -153,13 +153,13 @@ describe "ProjectRoles API" do
 
         let(:token) { authenticate(email: "random@user.com", password: "password") }
 
-        it "returns a 401 access denied" do
+        it "returns a 403 FORBIDDEN" do
           create(:project_role, id: 1, role: @role, project: @project)
 
           authenticated_delete "/project_roles/1", {}, token
 
-          expect(last_response.status).to eq 401
-          expect(json).to be_a_valid_json_api_error.with_id "ACCESS_DENIED"
+          expect(last_response.status).to eq 403
+          expect(json).to be_a_valid_json_api_error.with_id "FORBIDDEN"
           expect(ProjectRole.count).to eq 1
         end
       end

--- a/spec/requests/api/project_skills_spec.rb
+++ b/spec/requests/api/project_skills_spec.rb
@@ -153,13 +153,13 @@ describe "ProjectSkills API" do
 
         let(:token) { authenticate(email: "random@user.com", password: "password") }
 
-        it "returns a 401 access denied" do
+        it "returns a 403 FORBIDDEN" do
           create(:project_skill, id: 1, skill: @skill, project: @project)
 
           authenticated_delete "/project_skills/1", {}, token
 
-          expect(last_response.status).to eq 401
-          expect(json).to be_a_valid_json_api_error.with_id "ACCESS_DENIED"
+          expect(last_response.status).to eq 403
+          expect(json).to be_a_valid_json_api_error.with_id "FORBIDDEN"
           expect(ProjectSkill.count).to eq 1
         end
       end

--- a/spec/requests/api/role_skills_spec.rb
+++ b/spec/requests/api/role_skills_spec.rb
@@ -24,9 +24,9 @@ describe "RoleSkills API" do
           authenticated_post "/role_skills", nil, token
         end
 
-        it "responds with a 401 access denied" do
-          expect(last_response.status).to eq 401
-          expect(json).to be_a_valid_json_api_error.with_id "ACCESS_DENIED"
+        it "responds with a 403" do
+          expect(last_response.status).to eq 403
+          expect(json).to be_a_valid_json_api_error.with_id "FORBIDDEN"
         end
       end
 

--- a/spec/requests/api/roles_spec.rb
+++ b/spec/requests/api/roles_spec.rb
@@ -73,10 +73,10 @@ describe "Roles API" do
       end
 
       context "as a regular user" do
-        it "responds with a 401 access denied" do
+        it "responds with a 403 FORBIDDEN" do
           make_request(params)
-          expect(last_response.status).to eq 401
-          expect(json).to be_a_valid_json_api_error.with_id "ACCESS_DENIED"
+          expect(last_response.status).to eq 403
+          expect(json).to be_a_valid_json_api_error.with_id "FORBIDDEN"
         end
       end
 

--- a/spec/requests/api/skills_spec.rb
+++ b/spec/requests/api/skills_spec.rb
@@ -109,10 +109,10 @@ describe "Skills API" do
       end
 
       context "as a regular user" do
-        it "responds with a 401 access denied" do
+        it "responds with a 403 FORBIDDEN" do
           make_request(params)
-          expect(last_response.status).to eq 401
-          expect(json).to be_a_valid_json_api_error.with_id "ACCESS_DENIED"
+          expect(last_response.status).to eq 403
+          expect(json).to be_a_valid_json_api_error.with_id "FORBIDDEN"
         end
       end
 

--- a/spec/requests/api/user_categories_spec.rb
+++ b/spec/requests/api/user_categories_spec.rb
@@ -130,8 +130,8 @@ describe "UserCategories API" do
 
         authenticated_delete "/user_categories/1", {}, token
 
-        expect(last_response.status).to eq 401
-        expect(json).to be_a_valid_json_api_error.with_id "ACCESS_DENIED"
+        expect(last_response.status).to eq 403
+        expect(json).to be_a_valid_json_api_error.with_id "FORBIDDEN"
         expect(UserCategory.count).to eq 1
       end
 

--- a/spec/requests/api/user_roles_spec.rb
+++ b/spec/requests/api/user_roles_spec.rb
@@ -111,8 +111,8 @@ describe "UserRoles API" do
 
         authenticated_delete "/user_roles/1", {}, token
 
-        expect(last_response.status).to eq 401
-        expect(json).to be_a_valid_json_api_error.with_id "ACCESS_DENIED"
+        expect(last_response.status).to eq 403
+        expect(json).to be_a_valid_json_api_error.with_id "FORBIDDEN"
         expect(UserRole.count).to eq 1
       end
 

--- a/spec/requests/api/user_skills_spec.rb
+++ b/spec/requests/api/user_skills_spec.rb
@@ -183,8 +183,8 @@ describe "UserSkills API" do
 
         authenticated_delete "/user_skills/1", {}, token
 
-        expect(last_response.status).to eq 401
-        expect(json).to be_a_valid_json_api_error.with_id "ACCESS_DENIED"
+        expect(last_response.status).to eq 403
+        expect(json).to be_a_valid_json_api_error.with_id "FORBIDDEN"
         expect(UserSkill.count).to eq 1
       end
 

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -509,11 +509,11 @@ describe "Users API" do
           @token = authenticate(email: "regular@mail.com", password: "password")
         end
 
-        it "returns a 401 with a proper error message" do
+        it "returns a 403 FORBIDDEN" do
           authenticated_patch "/users/#{@edited_user.id}", @edit_params, @token
 
-          expect(last_response.status).to eq 401
-          expect(json).to be_a_valid_json_api_error.with_id("ACCESS_DENIED")
+          expect(last_response.status).to eq 403
+          expect(json).to be_a_valid_json_api_error.with_id("FORBIDDEN")
         end
       end
     end

--- a/spec/serializers/error_serializer_spec.rb
+++ b/spec/serializers/error_serializer_spec.rb
@@ -39,10 +39,10 @@ describe ErrorSerializer do
       expect(result[:errors].length).to eq 1
 
       error = result[:errors].first
-      expect(error[:id]).to eq "ACCESS_DENIED"
-      expect(error[:title]).to eq "Access denied"
+      expect(error[:id]).to eq "FORBIDDEN"
+      expect(error[:title]).to eq "Forbidden"
       expect(error[:detail]).to eq "You are not authorized to perform this action on users."
-      expect(error[:status]).to eq 401
+      expect(error[:status]).to eq 403
     end
 
     it "can serialize ActionController::ParameterMissing" do


### PR DESCRIPTION
This fixes #382. I read through the IETF on this and the logic is sound. This should also close an issue on the Ember side: https://github.com/code-corps/code-corps-ember/issues/50
