### PR TITLE
Improve Apiary documentation process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,19 +38,46 @@ Once you've created the issue, you can [make your changes and push them up](#how
 
 ## What kind of documentation are you writing?
 
-- [I want to improve the API developer docs.](#improving-the-api-docs)
-- [I want to document some of the internals of the Rails app](#improving-internal-docs).
-- [I want to improve the README.](#improving-the-readme)
+- [I want to improve the documentation of the API endpoints.](#improving-the-api-endpoint-docs)
+- [I want to document some of the internals of the Rails app](#improving-ruby-docs).
+- [I want to improve the docs on GitHub.](#improving-the-readme)
 
-## Improving the API docs
+## Improving the API endpoint docs
 
 We're still trying to figure this out, but you can [follow this journey issue](https://github.com/code-corps/code-corps-api/issues/387) and see some of the `Closed` pull requests for how to document.
 
 We're using [API Blueprint](https://apiblueprint.org/) for writing our docs, and you can use the Apiary CLI tool to preview them.
 
+#### Learning how to write API Blueprint documentation
+
+API Blueprint has a [quick tutorial you can read](https://apiblueprint.org/documentation/tutorial.html) that walks through writing your first docs in the API Blueprint language.
+
+You can [read more examples here](https://github.com/apiaryio/api-blueprint/tree/master/examples) or check our own blueprint for examples.
+
+#### Where do I make changes?
+
+You will be working with the `blueprint/api.apib` document. You'll likely be adding any number of:
+
+- Resource Groups
+- Resources
+- Actions
+- URI Templates
+- URI Parameters
+- Data Structures
+
+Data Structures often serve as your base objects for assembling the higher-level endpoint documentation. These objects are composeable – like Lego blocks – in new and often interesting ways.
+
+The `/users/:id` endpoint documented in the `User` resource group, for example, may contain a `User Response` for its `200` response. This `User Response` data structure is itself composed of a `User` data structure (which collects the attributes for that user like `email` and `username`) and a `User Relationships Base` data structure, which includes yet more data structures like the `User Skills Relationship`.
+
+By creating small, modular pieces, we can assemble complex data structures that describe our API.
+
+#### Previewing your changes
+
+You can preview your changes by [walking through our guide on how to generate API documentation locally](API.md).
+
 [Done with your changes?](#i-finished-my-changes)
 
-## Improving internal docs
+## Improving Ruby docs
 
 You can see how much code is documented on [Inch CI](http://inch-ci.org/github/code-corps/code-corps-api).
 

--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ group :development, :test do
 end
 
 group :development do
+  gem "apiary"
   gem "foreman"
   gem "guard-rspec", require: false
   gem "sinatra", github: "sinatra", require: nil # for Sidekiq UI to work in development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,13 @@ GEM
     annotate (2.7.1)
       activerecord (>= 3.2, < 6.0)
       rake (>= 10.4, < 12.0)
+    apiary (0.0.5)
+      callsite
+      http_router
+      parameters_extra (~> 0.2.0)
+      rack
+      thin
+      thin_async
     arel (7.0.0)
     aws-sdk (2.3.19)
       aws-sdk-resources (= 2.3.19)
@@ -88,6 +95,7 @@ GEM
     bullet (5.1.1)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.10.0)
+    callsite (0.0.11)
     capybara (2.7.1)
       addressable
       mime-types (>= 1.16)
@@ -193,6 +201,9 @@ GEM
       html-pipeline (>= 1.11)
       rouge (~> 1.8)
     http_parser.rb (0.6.0)
+    http_router (0.11.2)
+      rack (>= 1.0.0)
+      url_mount (~> 0.2.1)
     httpclient (2.8.0)
     i18n (0.7.0)
     jmespath (1.2.4)
@@ -246,6 +257,10 @@ GEM
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
     obscenity (1.0.2)
+    parameters_extra (0.2.0)
+      ruby2ruby (~> 1.2.4)
+      ruby_parser (~> 2.0)
+      sexp_processor (~> 3.0.4)
     pg (0.18.4)
     pkg-config (1.1.7)
     pry (0.10.3)
@@ -339,7 +354,12 @@ GEM
       rspec (~> 3.0, >= 3.0.0)
       sidekiq (>= 2.4.0)
     rspec-support (3.5.0)
+    ruby2ruby (1.2.5)
+      ruby_parser (~> 2.0)
+      sexp_processor (~> 3.0)
     ruby_dep (1.3.1)
+    ruby_parser (2.3.1)
+      sexp_processor (~> 3.0)
     safe_yaml (1.0.4)
     searchkick (1.3.0)
       activemodel
@@ -353,6 +373,7 @@ GEM
     sequenced (3.1.1)
       activerecord (>= 3.0)
       activesupport (>= 3.0)
+    sexp_processor (3.0.10)
     shellany (0.0.1)
     shoulda-matchers (3.0.1)
       activesupport (>= 4.0.0)
@@ -382,6 +403,8 @@ GEM
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
+    thin_async (0.3.0)
+      thin (>= 1.2.1)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
@@ -389,6 +412,8 @@ GEM
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uniform_notifier (1.10.0)
+    url_mount (0.2.1)
+      rack
     vcr (3.0.3)
     webmock (2.1.0)
       addressable (>= 2.3.6)
@@ -408,6 +433,7 @@ DEPENDENCIES
   active_model_serializers (= 0.10.1)
   analytics-ruby
   annotate
+  apiary
   aws-sdk
   bullet
   capybara
@@ -461,6 +487,9 @@ DEPENDENCIES
   strip_attributes
   vcr
   webmock
+
+RUBY VERSION
+   ruby 2.2.5p319
 
 BUNDLED WITH
    1.12.5

--- a/README.md
+++ b/README.md
@@ -36,29 +36,14 @@ Have everything installed and ready to work? [Read our usage guides](docs/USAGE.
 
 ## API Docs
 
-You can generate documentation by navigating into the `/blueprint` directory.
+Want to see documentation for the API endpoints?
 
-If installing for the first time, run:
+Documentation is available on Apiary for the following branches:
 
-```shell
-docker-compose build
-```
+- `master` (api.codecorps.org): [http://docs.codecorpsapi.apiary.io/](http://docs.codecorpsapi.apiary.io/)
+- `develop` (api.pbqrpbecf.org and api.pbqrpbecf-qri.org): [http://docs.codecorpsapidevelop.apiary.io/](http://docs.codecorpsapidevelop.apiary.io/)
 
-Then start the `aglio` service with:
-
-```shell
-docker-compose up
-```
-
-Now you can generate the docs with our shell script:
-
-```bash
-./generate
-```
-
-You should be able to view the docs by opening the newly generated `index.html` in your browser.
-
-If you're developing with [Atom](https://atom.io/), you can also use the [API Blueprint Preview](https://atom.io/packages/api-blueprint-preview) package to preview your blueprint changes in realtime.
+Read our guide to see how to [generate API docs locally as you develop](docs/API.md).
 
 ## Built with
 

--- a/circle.yml
+++ b/circle.yml
@@ -9,9 +9,11 @@ deployment:
       - heroku run rake db:migrate --app code-corps-development
       - git push git@heroku.com:code-corps-staging.git $CIRCLE_SHA1:master
       - heroku run rake db:migrate --app code-corps-staging
+      - apiary publish --api-name="codecorpsapidevelop" --path ./blueprint/api.apib
   production:
     branch: master
     commands:
       - "[[ ! -s \"$(git rev-parse --git-dir)/shallow\" ]] || git fetch --unshallow"
       - git push git@heroku.com:code-corps.git $CIRCLE_SHA1:master
       - heroku run rake db:migrate --app code-corps
+      - apiary publish --api-name="codecorpsapi" --path ./blueprint/api.apib

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,14 @@ services:
       RAILS_ENV: test
     ports: []
 
+  apiary:
+    image: apiaryio/client
+    command: preview --server --host=0.0.0.0 --port=8080 --path=/code-corps-api/blueprint/api.apib
+    ports:
+      - 8081:8080
+    volumes:
+      - .:/code-corps-api
+
 volumes:
   postgres-data:
   redis-data:
-

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,41 @@
+# How to generate API documentation locally
+
+You can generate documentation a few ways:
+
+- [Apiary CLI](#apiary-cli) (recommended)
+- [`aglio`](#aglio)
+- [Atom](#atom)
+
+### Apiary CLI
+
+[Apiary CLI](https://help.apiary.io/tools/apiary-cli/) comes preloaded when you run `docker-compose up` like normal.
+
+Once Docker is running your containers, `apiary` runs an Apiary CLI server on port `8081`. You can visit the documentation by visiting `localhost:8081` in your browser. Just refresh the page any time you make changes to the documentation file at `/blueprint/api.apib`.
+
+### aglio
+
+Navigate into the `/blueprint` directory.
+
+If installing for the first time, run:
+
+```shell
+docker-compose build
+```
+
+Then start the `aglio` service with:
+
+```shell
+docker-compose up
+```
+
+Now you can generate the docs with our shell script:
+
+```bash
+./generate
+```
+
+You should be able to view the docs by opening the newly generated `index.html` in your browser.
+
+### Atom
+
+If you're developing with [Atom](https://atom.io/), you can also use the [API Blueprint Preview](https://atom.io/packages/api-blueprint-preview) package to preview your blueprint changes in realtime.

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -25,7 +25,7 @@ code-corps-api/          # → Root folder for this project
 
 ### Setup your Docker containers and run the server
 
-> Note: We bind to ports 6380 for `redis` and 5001 for `foreman`. Make sure you're not running anything on those ports. We do not expose port 5432 for `postgres` or 9200 for `elasticsearch`.
+> Note: We bind to ports 80 for `web`, 8081 for `apiary`, 6380 for `redis` and 5001 for `foreman`. Make sure you're not running anything on those ports. We do not expose port 5432 for `postgres` or 9200 for `elasticsearch`.
 
 Go to the `code-corps-api` directory and type:
 
@@ -43,6 +43,7 @@ Docker will set up your base Ruby container, as well as containers for:
 - `redis`
 - `web` runs `foreman s` with the `Procfile.dev`
 - `test` runs `guard start`
+- `apiary` runs an [Apiary client](API.md#apiary-cli) server on port `8081`
 
 You can view more detailed information about these services in the `docker-compose.yml` file, but you shouldn't need to edit it unless you're intentionally contributing changes to our Docker workflow.
 


### PR DESCRIPTION
This PR:
- adds commands to push the API docs to Circle
- adds the ability to run an apiary server locally with Docker
- adds more to the documentation itself 
