### PR TITLE
Added documentation for comments API

### DIFF
--- a/blueprint/api.apib
+++ b/blueprint/api.apib
@@ -138,6 +138,148 @@ Exchange credentials for `access_token`.
 
 # Group Comments
 
+## Comments [/comments]
+
+<<<<<<< HEAD
+### Filter comments by list of ids [GET /comments{?filter[id]}]
+
++ Parameters
+
+    + `filter[id]`: `1,2,3` (string, required) - Comma separated string of `ids` to filter by.
+
+        Technically, the parameter is `filter: { id: '1,2,3' }`, which ends up being serialized into `filter[id]`. However, synthax constraints to not allow us to define it in the documentation this way.
+
+
++ Request
+
+    + Headers
+
+        Accept: application/vnd.api+json
+
+        Authorization: Bearer {access_token}
+
++ Response 200 (application/vnd.api+json)
+
+    + Attributes (Comments Response)
+
+## List comments for a specified post [GET /posts/{number}/comments]
+
++ Parameters
+
+    + number: 1 (number, required) - Post number, uniquely identifying a post
+
++ Request
+
+    + Headers
+
+        Accept: application/vnd.api+json
+
+        Authorization: Bearer {access_token}
+
++ Response 200 (application/vnd.api+json)
+
+    + Attributes (Comments Response)
+
+### Create a comment [POST]
+
++ Request
+    + Headers
+
+        Accept: application/vnd.api+json
+
+        Authorization: Bearer {access_token}
+
+    + Attributes (Comment Create Request)
+=======
+### Create a comment [POST]
+
++ Request
+
+    + Attributes (Comment Create Request)
+
++ Headers
+
+    Authorization: Basic 5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8
+
++ Response 201 (application/vnd.api+json)
+
+    + Attributes (Comment Response)
+
++ Response 422 (application/vnd.api+json)
+
+    + Attributes (Unprocessable Entity Response)
+
+### Update a comment [PATCH /comments/{id}]
+
++ Request
+
+    + Attributes (Comment Update Request)
+
++ Headers
+
+    Authorization: Basic 5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8
+>>>>>>> dcb1458... Added documentation for comment API
+
++ Response 201 (application/vnd.api+json)
+
+    + Attributes (Comment Response)
+
++ Response 422 (application/vnd.api+json)
+
+    + Attributes (Unprocessable Entity Response)
+
+<<<<<<< HEAD
+## Comment [/comments/{id}]
+
++ Parameters
+
+    + id: `1` (string, required) - Comment id, uniquely identifying a comment
+
+### Update a comment [PATCH]
+
++ Request
+
+    + Headers
+
+        Accept: application/vnd.api+json
+
+        Authorization: Bearer {access_token}
+
+    + Attributes (Comment Update Request)
+
++ Response 201 (application/vnd.api+json)
+
+    + Attributes (Comment Response)
+
++ Response 422 (application/vnd.api+json)
+
+    + Attributes (Unprocessable Entity Response)
+=======
+### List comments with specified ids [GET]
+
++ Request
+
+    + Attributes (Id Filter)
+
++ Headers
+
+    Authorization: Basic 5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8
+
++ Response 200 (application/vnd.api+json)
+
+    + Attributes (Comments Response)
+
+## List comments for a specified post [GET /posts/:number/comments]
+
++ Headers
+
+    Authorization: Basic 5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8
+
++ Response 200 (application/vnd.api+json)
+
+    + Attributes (Comments Response)
+>>>>>>> dcb1458... Added documentation for comment API
+
 # Group Github Repositories
 
 # Group Import Skill Failures
@@ -1059,7 +1201,7 @@ This endpoint retrieves sets of users and skills to act as a join table between 
 
 ## Comment Image Relationships Base (object)
 + comment
-  + data(Comments Relationship)
+  + data(Comment Resource Identifier)
 + user
   + data(User Resource Identifier)
 
@@ -1072,9 +1214,77 @@ This endpoint retrieves sets of users and skills to act as a join table between 
 ## Comment Image Response (object)
 + data(Comment Image Response Base)
 
-## Comments Relationship (object)
-+ id: 1 (string)
-+ type: comments (string)
+## Comment Resource (object)
++ include Comment Resource Identifier
++ attributes(Comment Attributes)
++ relationships
+    + posts
+        + data(Post Resource Identifier)
+        + links (object)
+    + users
+        + data(User Resource Identifier)
+        + links (object)
+    + comment_user_mentions
+        + data(array[Comment User Mention Resource Identifier])
+        + links (object)
+
+## Comment Attributes (object)
++ markdown: `Markdown formatted string` (string)
++ body: `Html string rendered from markdown` (string)
++ state: (enum[string])
+    + Members
+        + `published`
+        + `edited`
++ edited_at: `2014-07-07T18:01:26.000Z` (string)
++ created_at: `2014-07-07T18:01:26.000Z` (string)
+
+## Comment Resource Identifier (object)
++ id: `1` (string)
++ type: `comments` (string)
+
+## Comment Create Request (object)
++ type: `comments` (string)
++ attributes
+    + markdown: `Markdown formatted string` (string)
++ relationships
+    + posts
+        + data(Post Resource Identifier)
+
+## Comment Update Request (object)
++ include Comment Resource Identifier
++ attributes
+    + markdown: `Markdown formatted content` (string)
+
+## Comment Response (object)
++ data
+    + include Comment Resource
++ included(array[Comment User Mention Resource])
+
+## Comments Response (object)
++ comments
+    + data(array[Comment Response], required)
++ included(array[Comment User Mention Resource])
+
+## Comment User Mention Resource (object)
++ include Comment User Mention Resource Identifier
++ attributes
+    + include Comment User Mention Attributes
++ relationships
+    + users
+        + data(User Resource Identifier)
+        + links (object)
+    + comments
+        + data(Comment Resource Identifier)
+        + links (object)
+
+## Comment User Mention Attributes (object)
++ indices: 1, 2 (array[number])
+    The start and the end index of where the mention is to be placed within the comment body
++ username: 'Username of related user' (string)
+
+## Comment User Mention Resource Identifier (object)
++ id: `1` (string)
++ type: `comment_user_mentions` (string)
 
 ## Creation Conflict Response (object)
 + title: `Conflict` (string)
@@ -1200,6 +1410,10 @@ This endpoint retrieves sets of users and skills to act as a join table between 
 ## Organization Membership Update Request (object)
 + include Organization Membership Resource Identifier
 + attributes(Organization Membership Attributes)
+
+## Post Resource Identifier
++ id: `1` (string)
++ type: `posts` (string)
 
 ## Preview (object)
 + body: `<p>A <strong>strong</strong> preview</p>` (string)


### PR DESCRIPTION
Closes #403

I did a sort of risky thing and decided to try a different naming approach as a sort of proposal to how we could do it in the future.

My issue with what we currently have is that the object names are very similar.

For example, with the current scheme, we would have:
- Comments Relationships - shows related comments in other objects, ex. posts, users, etc.
- Comments Relationship - a single { id, type } hash, multiple of which are contained in Comments Relationships
- Comment Relationships - a list of objects related to the current comment, part of a single Comment's response. With my current proposal, we would have. In this specific case, it would include Users Relationships, Posts Relationships and Comment User Mentions Relationships

With my proposal, we would have

```
Comment
+ body, markdown, created_at, etc.

Head For Comment
+ id, type

Attributes For Comment
+ attributes: (Comment, required)

Relationships For Comment
+ relationships: 
   + include Related Posts
   + include Related Users
   + Related Comment User Mentions

Comment Response
+ Head For Comment
+ Attributes For Comment
+ Relationships For Comment
```

If another object is related to comments, it would have a (with an example of a post)

```
Relationships For Post
+ relationships:
   + include Related Comments
```

Where related comments would look like:

```
Related Comments
  + data(array[Head For Comment])
```

In my opinion, I think it makes the documentation less confusing, but I'm always open to critique. @JoshSmith @green-arrow @npendery, what do you think?
