### PR TITLE
Remove duplicate users relationship from API Blueprint

### DIFF
--- a/blueprint/api.apib
+++ b/blueprint/api.apib
@@ -394,10 +394,6 @@ Exchange credentials for `access_token`.
 + id: 1 (string)
 + type: user_categories (string)
 
-## Users Relationship
-+ id: 1 (string)
-+ type: users (string)
-
 ## User Relationships Base (object)
 + include User Roles Relationships
 + include User Skills Relationships


### PR DESCRIPTION
When I rebased https://github.com/code-corps/code-corps-api/pull/456, a duplicate `Users Relationship` was accidentally included, which broke API blueprint. This removes that duplicate as a fix.
