### PR TITLE
Enable apiary in test environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ end
 
 group :development, :test do
   gem "annotate"
+  gem "apiary"
   gem "bullet"
   gem "dotenv-rails"
   gem "fakeredis", require: "fakeredis/rspec"
@@ -57,7 +58,6 @@ group :development, :test do
 end
 
 group :development do
-  gem "apiary"
   gem "foreman"
   gem "guard-rspec", require: false
   gem "sinatra", github: "sinatra", require: nil # for Sidekiq UI to work in development


### PR DESCRIPTION
The following failure has been surfacing during ci builds:

```
$ apiary publish --api-name="codecorpsapidevelop" --path ./blueprint/api.apib

bash: line 1: apiary: command not found

apiary publish --api-name="codecorpsapidevelop" --path ./blueprint/api.apib returned exit code 127
```

This update adds the `apiary` gem to the test group, so that the `apiary` command is available during builds.

cc: @JoshSmith 
