### PR TITLE
Use “apiaryio” gem over “apiary”

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ end
 
 group :development, :test do
   gem "annotate"
-  gem "apiary"
+  gem "apiaryio"
   gem "bullet"
   gem "dotenv-rails"
   gem "fakeredis", require: "fakeredis/rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,13 +74,9 @@ GEM
     annotate (2.7.1)
       activerecord (>= 3.2, < 6.0)
       rake (>= 10.4, < 12.0)
-    apiary (0.0.5)
-      callsite
-      http_router
-      parameters_extra (~> 0.2.0)
-      rack
-      thin
-      thin_async
+    apiaryio (0.0.1)
+      launchy (>= 0.3.2)
+      rest-client (~> 1.6.1)
     arel (7.0.0)
     aws-sdk (2.3.19)
       aws-sdk-resources (= 2.3.19)
@@ -95,7 +91,6 @@ GEM
     bullet (5.1.1)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.10.0)
-    callsite (0.0.11)
     capybara (2.7.1)
       addressable
       mime-types (>= 1.16)
@@ -201,9 +196,6 @@ GEM
       html-pipeline (>= 1.11)
       rouge (~> 1.8)
     http_parser.rb (0.6.0)
-    http_router (0.11.2)
-      rack (>= 1.0.0)
-      url_mount (~> 0.2.1)
     httpclient (2.8.0)
     i18n (0.7.0)
     jmespath (1.2.4)
@@ -220,6 +212,8 @@ GEM
       addressable
       faraday
       multi_json
+    launchy (2.4.3)
+      addressable (~> 2.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -257,10 +251,6 @@ GEM
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
     obscenity (1.0.2)
-    parameters_extra (0.2.0)
-      ruby2ruby (~> 1.2.4)
-      ruby_parser (~> 2.0)
-      sexp_processor (~> 3.0.4)
     pg (0.18.4)
     pkg-config (1.1.7)
     pry (0.10.3)
@@ -329,6 +319,8 @@ GEM
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
     redis (3.3.0)
+    rest-client (1.6.7)
+      mime-types (>= 1.16)
     rouge (1.11.1)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -354,12 +346,7 @@ GEM
       rspec (~> 3.0, >= 3.0.0)
       sidekiq (>= 2.4.0)
     rspec-support (3.5.0)
-    ruby2ruby (1.2.5)
-      ruby_parser (~> 2.0)
-      sexp_processor (~> 3.0)
     ruby_dep (1.3.1)
-    ruby_parser (2.3.1)
-      sexp_processor (~> 3.0)
     safe_yaml (1.0.4)
     searchkick (1.3.0)
       activemodel
@@ -373,7 +360,6 @@ GEM
     sequenced (3.1.1)
       activerecord (>= 3.0)
       activesupport (>= 3.0)
-    sexp_processor (3.0.10)
     shellany (0.0.1)
     shoulda-matchers (3.0.1)
       activesupport (>= 4.0.0)
@@ -403,8 +389,6 @@ GEM
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
-    thin_async (0.3.0)
-      thin (>= 1.2.1)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
@@ -412,8 +396,6 @@ GEM
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uniform_notifier (1.10.0)
-    url_mount (0.2.1)
-      rack
     vcr (3.0.3)
     webmock (2.1.0)
       addressable (>= 2.3.6)
@@ -433,7 +415,7 @@ DEPENDENCIES
   active_model_serializers (= 0.10.1)
   analytics-ruby
   annotate
-  apiary
+  apiaryio
   aws-sdk
   bullet
   capybara


### PR DESCRIPTION
Oops! The intended gem for the [Apiary.io client](https://github.com/apiaryio/apiary-client) is `apiaryio` instead of `apiary`. This update swaps out the correct gem.
