### PR TITLE
Install apiaryio via deployment commands

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,7 @@ deployment:
       - heroku run rake db:migrate --app code-corps-development
       - git push git@heroku.com:code-corps-staging.git $CIRCLE_SHA1:master
       - heroku run rake db:migrate --app code-corps-staging
+      - gem install apiaryio
       - apiary publish --api-name="codecorpsapidevelop" --path ./blueprint/api.apib
   production:
     branch: master
@@ -16,4 +17,5 @@ deployment:
       - "[[ ! -s \"$(git rev-parse --git-dir)/shallow\" ]] || git fetch --unshallow"
       - git push git@heroku.com:code-corps.git $CIRCLE_SHA1:master
       - heroku run rake db:migrate --app code-corps
+      - gem install apiaryio
       - apiary publish --api-name="codecorpsapi" --path ./blueprint/api.apib


### PR DESCRIPTION
This update installs the `apiary` command on the test machine by manually gem installing `apiaryio` before publishing. 

cc: @JoshSmith 
