### PR TITLE
Fix role skill resource relationships

### DIFF
--- a/blueprint/api.apib
+++ b/blueprint/api.apib
@@ -587,8 +587,8 @@ This allows A Skill to be under different Roles and a Role to have multiple Skil
 + include Role Skill Resource Identifier
 + relationships
   + roles
-    + data(array[Roles Relationship])
-    + data(array[Skills Relationship])
+    + data(array[Role Resource Identifier])
+    + data(array[Skill Resource Identifier])
     + links
 
 ## Role Skill Resource Identifier (object)


### PR DESCRIPTION
In #464 these data structures were renamed as resource identifiers. This update reflects the change within the role skills relationship collections.
