### PR TITLE
Add documentation for projects API endpoint

### DIFF
--- a/blueprint/api.apib
+++ b/blueprint/api.apib
@@ -689,6 +689,76 @@ Write privileges are for admin users only, read can be accessable by any user.
 
 # Group Projects
 
+## Projects [/projects]
+
+### List all projects [GET]
+
++ Headers
+
+  Authorization: Bearer {access_token}
+
++ Response 200 (application/vnd.api+json)
+
+  + Attributes (Projects Response)
+
+### Retrieve a project [GET /projects/:id]
+
++ Headers
+
+  Authorization: Bearer {access_token}
+
++ Response 200 (application/vnd.api+json)
+
+  + Attributes (Project Response)
+
+### Retrieve all projects for organization specified by slug [GET /:slug/projects]
+
++ Headers
+
+  Authorization: Bearer {access_token}
+
++ Response 200 (application/vnd.api+json)
+
+  + Attributes (Projects Response)
+
+### Retrieve a project by slug [GET /:slug/:project_slug]
+
++ Headers
+
+  Authorization: Bearer {access_token}
+
++ Response 200 (application/vnd.api+json)
+
+  + Attributes (Project Response)
+
+### Create a project [POST]
+
++ Request
+
+  + Attributes (Project Create Request)
+
++ Headers
+
+  Authorization: Bearer {access_token}
+
++ Response 200 (application/vnd.api+json)
+
+  + Attributes (Project Response)
+
+### Update a project [PATCH /projects/:id]
+
++ Request
+
+  + Attributes (Project Update Request)
+
++ Headers
+
+  Authorization: Bearer {access_token}
+
++ Response 200 (application/vnd.api+json)
+
+  + Attributes (Project Response)
+
 # Group Roles
 
 This endpoint is for creating and returning the roles available for users.
@@ -1477,6 +1547,10 @@ This endpoint retrieves sets of users and skills to act as a join table between 
 + filter:
     + id: `1,2,3,...` (string, required) - A list of ids, in a single string, comma-separated
 
+## Github Repository Resource Identifier
++ id: `1` (string)
++ type: `github_repositories` (string)
+
 ## No Content Response (object)
 
     {}
@@ -1631,12 +1705,65 @@ This endpoint retrieves sets of users and skills to act as a join table between 
 ## Project Category Create Request (object)
 + data(Project Category Resource)
 
-# Project Category Response (object)
+## Project Category Response (object)
 + data(Project Category Resource)
 
-## Project Resource Identifier
+## Project Resource (object)
++ include Project Resource Identifier
++ attributes(Project Attributes)
++ relationships
+    + categories
+        + data(array[Category Resource Identifier])
+    + github_repositories
+        + data(array[Github Repository Resource Identifier])
+    + roles
+        + data(array[Role Resource Identifier])
+    + skills
+        + data(array[Skill Resource Identifier])
+    + organizations
+        + data(Organization Resource Identifier)
+
+## Project Resource Identifier (object)
 + id: `1` (string)
 + type: `projects` (string)
+
+## Project Attributes (object)
++ slug: 'code_corps' (string) - Case insensitive unique string identifier for the project
++ title: 'Code Corps' (string) - A title for the project
++ description: 'Help build and fund public software projects for social good.' (string) - A short plain text description for the project
++ icon_thumb_url: 'example.com/icon_thumb.png' (string) - A url pointing to the project thumbnail
++ icon_large_url: 'example.com/icon_large.png' (string) - A url pointing to a large icon for the project
++ long_description_body: 'Example <b>html</b>' (string) - A html string containing the rendered long_description_markdown
++ long_description_markdown: 'Example **markdown**' (string) - Markdown formatted string containing the project long description
++ open_posts_count: 27 (number) - Number of open posts created for the project
++ closed_posts_count: 4 (number) - Number of closed posts created for the project
+
+## Projects Response
++ data(array[Project Resource])
+
+## Project Response
++ data(Project Resource)
+
+## Project Create Request
++ data
+    + attributes
+        + base64_icon_data (string) - A base64 encoded string containing the project icon
+        + title (string) - A title for the project
+        + description (string) - A short plain text description for the project
+        + slug (string) - Case insensitive unique string identifier for the project
+        + long_description_markdown (string) - Markdown formatted string containing the project long description
+    + relationships
+        + organizations
+            + data(Organization Resource Identifier) - Identifier of organization this project is being created for
+
+## Project Update Request
++ data
+    + attributes
+        + base64_icon_data (string) - A base64 encoded string containing the project icon
+        + title (string) - A title for the project
+        + description (string) - A short plain text description for the project
+        + slug (string) - Case insensitive unique string identifier for the project
+        + long_description_markdown (string) - Markdown formatted string containing the project long description
 
 ## Record Not Found Response (object)
 + errors (array)


### PR DESCRIPTION
Closes #421, but there are a couple of items here that are worth discussing first
- We have an endpoint to list all projects from a specified slugged route. This is a remnant from when a project could belong to a user or an organization. It can only belong to an organization now. Should it be removed, or possibly redefined to work differently? Perhaps the `GET /projects` endpoint should support an `organization_id` parameter?
- We have an endpoint to fetch a project by `:slugged_route/:slug`, which is redundant, really. Our client will always have access to the project id when needing to fetch a project and we already have an endpoint to fetch by id directly. Should we remove the fetch by slug endpoint?
- Project#show includes github_repositories in the payload (not just the relationships. the actual includes as well). Should that be removed, considering it doesn't really do anything right now? Should we even include the github relationship in the payload, considering we don't have it working yet?
- Project#create and Project#update currently allow us to send a slug alongside the request. Should it not be auto-generated from the title?
- Project#create currently sets organization as part of the attributes payload, which is not according to JSON API spec. I have added the relationship, even though it doesn't match our current API. We cannot infer it from the current user, since the current user can belong to multiple organizations where they are able to create projects.
- Should we have a Project#create at all right now?
